### PR TITLE
Fix/signup : 로그인 오류 메시지 수정 및 한영 토글 구현

### DIFF
--- a/src/apis/signInApi.jsx
+++ b/src/apis/signInApi.jsx
@@ -5,10 +5,21 @@ const signInApi = async (body) => {
     const response = await api.post("user/login", body);
     return response.data;
   } catch (err) {
-    if (err.response?.data?.message) {
-      throw new Error(err.response.data.message);
+    if (err.response?.data) {
+      const data = err.response.data;
+
+  
+      if (data.message) {
+        throw new Error(data.message);
+      }
+      const messages = Object.entries(data)
+        .filter(([key]) => key !== "status")
+        .map(([_, value]) => value)
+        .join("  ");
+
+      throw new Error(messages);
     } else if (err.response) {
-      throw new Error(`오류 발생 (status: ${err.response.status})`);
+      throw new Error("요청이 올바르지 않습니다.");
     } else if (err.request) {
       throw new Error("서버로부터 응답이 없습니다.");
     } else {

--- a/src/components/LanguageSelect.jsx
+++ b/src/components/LanguageSelect.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const LANGS = [
+  { code: "ko", label: "한국어", flag: "🇰🇷" },
+  { code: "en", label: "English", flag: "🇺🇸" },
+];
+
+export default function LanguageSelect() {
+  const { i18n } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef(null);
+  const menuRef = useRef(null);
+
+  const current = LANGS.find(l => i18n.language?.startsWith(l.code)) || LANGS[0];
+
+  // ✅ 버튼은 메뉴만 열고 닫음. 언어 전환 없음.
+  const toggleMenu = () => setOpen(v => !v);
+
+  // ✅ 메뉴 항목 클릭 시에만 언어 전환.
+  const selectLang = (code) => {
+    if (!i18n.language?.startsWith(code)) {
+      i18n.changeLanguage(code);
+      // 원하면 저장: localStorage.setItem("lang", code);
+    }
+    setOpen(false);
+  };
+
+  // 바깥 클릭 시 닫기
+  useEffect(() => {
+    const onDocClick = (e) => {
+      if (!btnRef.current?.contains(e.target) && !menuRef.current?.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, []);
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        onClick={toggleMenu}
+        className="flex items-center gap-2 px-4 py-2 rounded-xl bg-white/10 hover:bg-white/20
+                   backdrop-blur border border-white/20 text-white"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="opacity-80">Select Language</span>
+        <span className="text-sm">▼</span>
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute right-0 mt-2 w-56 rounded-2xl bg-white/10 backdrop-blur
+                     border border-white/20 shadow-lg p-1 text-white"
+          role="listbox"
+        >
+          {LANGS.map((l) => {
+            const active = i18n.language?.startsWith(l.code);
+            return (
+              <button
+                key={l.code}
+                onClick={() => selectLang(l.code)} 
+                role="option"
+                aria-selected={active}
+                className={`w-full flex items-center gap-3 px-4 py-2 rounded-xl
+                           hover:bg-white/20 ${active ? "bg-white/20" : ""}`}
+              >
+                <span className="text-xl">{l.flag}</span>
+                <span className="flex-1">{l.label}</span>
+                {active && <span>✓</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/LanguageSelect.jsx
+++ b/src/components/LanguageSelect.jsx
@@ -2,8 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const LANGS = [
-  { code: "ko", label: "한국어", flag: "🇰🇷" },
-  { code: "en", label: "English", flag: "🇺🇸" },
+  { code: "ko", label: "한국어", flag: "KR" },
+  { code: "en", label: "English", flag: "US" },
 ];
 
 export default function LanguageSelect() {
@@ -14,19 +14,18 @@ export default function LanguageSelect() {
 
   const current = LANGS.find(l => i18n.language?.startsWith(l.code)) || LANGS[0];
 
-  // ✅ 버튼은 메뉴만 열고 닫음. 언어 전환 없음.
+
   const toggleMenu = () => setOpen(v => !v);
 
-  // ✅ 메뉴 항목 클릭 시에만 언어 전환.
+
   const selectLang = (code) => {
     if (!i18n.language?.startsWith(code)) {
       i18n.changeLanguage(code);
-      // 원하면 저장: localStorage.setItem("lang", code);
     }
     setOpen(false);
   };
 
-  // 바깥 클릭 시 닫기
+
   useEffect(() => {
     const onDocClick = (e) => {
       if (!btnRef.current?.contains(e.target) && !menuRef.current?.contains(e.target)) {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 import AuthContext from "../contexts/AuthContext";
 import userGetApi from "../apis/userGetApi";
 import logoutApi from "../apis/logoutApi"; 
+import { useTranslation } from "react-i18next";
 
 const Sidebar = ({ isOpen, setIsOpen }) => {
     const navigate = useNavigate()
@@ -12,6 +13,7 @@ const Sidebar = ({ isOpen, setIsOpen }) => {
 
   const [nickname, setNickname] = useState("user");
   const [progress] = useState(34);  // 진행도 -> 더미데이터
+   const { t } = useTranslation();
   const isLoggedIn = !!accessToken;
 
   useEffect(() => {
@@ -132,21 +134,21 @@ const handleLogout = async () => {
           <nav className="flex flex-col gap-6 text-xl">
             {isLoggedIn ? (
               <>
-                <Link to="/" onClick={closeAnd()} aria-label="Home">
-                  Home
-                </Link>
-                <Link to="/sky" onClick={closeAnd()} aria-label="My Constellation">
-                  Night Sky Page
-                </Link>
-                <Link to="/calendar" onClick={closeAnd()} aria-label="Star Calendar">
-                  My Diary
-                </Link>
-                <Link to="/archive" onClick={closeAnd()} aria-label="Constellation Repo">
-                  Constellation Archive
-                </Link>
-                <Link to="/mypage" onClick={closeAnd()} aria-label="My Page">
-                  My Page
-                </Link>
+               <Link to="/" onClick={closeAnd()} aria-label={t("navbar.home")}>
+                {t("navbar.home")}
+              </Link>
+              <Link to="/sky" onClick={closeAnd()} aria-label={t("navbar.NightSkyPage")}>
+                {t("navbar.NightSkyPage")}
+              </Link>
+              <Link to="/calendar" onClick={closeAnd()} aria-label={t("navbar.MyDiary")}>
+                {t("navbar.MyDiary")}
+              </Link>
+              <Link to="/archive" onClick={closeAnd()} aria-label={t("navbar.ConstellationArchive")}>
+                {t("navbar.ConstellationArchive")}
+              </Link>
+              <Link to="/mypage" onClick={closeAnd()} aria-label={t("navbar.MyPage")}>
+                {t("navbar.MyPage")}
+              </Link>
               </>
             ) : (
               <>
@@ -157,14 +159,16 @@ const handleLogout = async () => {
         </div>
 
       
-        {isLoggedIn && (
-          <button
-            className="mt-auto text-left  mb-2 text-xl" 
-            onClick={handleLogout}
-          >
-            LOGOUT
-          </button>
-        )}
+      {isLoggedIn && (
+  <button
+    className="mt-auto text-left mb-2 text-xl"
+    onClick={handleLogout}
+    aria-label={t("navbar.Logout")}
+  >
+    {t("navbar.Logout")} 
+  </button>
+)}
+
       </div>
     </aside>
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -19,5 +19,13 @@
   "card.archive.subtitle1": "See the constellations",
   "card.archive.subtitle2": "you created",
 
+  "navbar.home": "Home",
+  "navbar.NightSkyPage": "Night Sky Page",
+  "navbar.MyDiary": "My Diary",
+  "navbar.ConstellationArchive": "Constellation Archive",
+  "navbar.MyPage": "My Page",
+
+  "navbar.Logout": "LOGOUT",
+
   "lang.toggle": "한"
 }

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -19,5 +19,13 @@
   "card.archive.subtitle1": "당신이 만든 별자리를",
   "card.archive.subtitle2": "확인해보세요",
 
+  "navbar.home": "홈 화면",
+  "navbar.NightSkyPage": "밤하늘 페이지",
+  "navbar.MyDiary": "나의 일기",
+  "navbar.ConstellationArchive": "별자리 아카이브",
+  "navbar.MyPage": "마이페이지",
+
+   "navbar.Logout": "로그아웃",
+
   "lang.toggle": "EN"
 }

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -7,7 +7,7 @@ import archiveImg from "../assets/archiveImg.png"
 import { useTranslation } from "react-i18next";
 import Sidebar from '../components/Sidebar';
 import AuthContext from "../contexts/AuthContext";
-
+import LanguageSelect from '../components/LanguageSelect';
 
 const MainPage = () => {
    const { t, i18n } = useTranslation();
@@ -16,11 +16,6 @@ const MainPage = () => {
    const isLoggedIn = !!accessToken;
 
    const navigate = useNavigate();
-
-  const toggleLang = () => {
-    const next = i18n.language.startsWith("ko") ? "en" : "ko";
-    i18n.changeLanguage(next);
-  };
   
   return (
     <>
@@ -45,23 +40,16 @@ const MainPage = () => {
         </button>
        {isLoggedIn ? (
 
-    <div className='flex mt-[1.37rem] gap-[1.37rem] items-center mr-10'>
-     <button onClick={toggleLang} className="text-[1.25rem]" aria-label="toggle language" title="toggle language">
-       {t("lang.toggle")}
-     </button>
-   </div>
- ) : (
+        <div className='flex mt-[1.37rem] gap-[1.37rem] items-center mr-10'>
+          <LanguageSelect />
+        </div>
+          
+        ) : (
   
    <>
-   <div className='flex flex-row justify-center items-center gap-[1.37rem]'> 
-     <button
-       onClick={toggleLang}
-       className="text-[1.25rem]"
-       aria-label="toggle language"
-       title="toggle language"
-     >
-       {t("lang.toggle")}
-     </button>
+      <div className='flex mt-[1.37rem] gap-[1.37rem] items-center mr-10'>
+        <LanguageSelect />
+
      <div className='flex gap-[1.37rem] items-center mr-[3.06rem]'>
        <Link to='/signin' className='text-[1.25rem]'>{t("menu.login")}</Link>
        <Link to='/signup' className='text-[1.25rem]'>{t("menu.signup")}</Link>

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -86,14 +86,6 @@ const [email, setEmail] = useState("");
     <div className="flex items-center mt-[10px]">
  <div className="w-[554px] flex justify-start mt-[10px]">
   <label className="flex items-center gap-[10px] cursor-pointer">
-    
-    <input
-      type="checkbox"
-      checked={remember}
-      onChange={() => setRemember(!remember)}
-      className="w-[20px] h-[20px] accent-blue-400"
-    />
-    <span className='text-[20px]'>로그인 상태 유지</span>
 
   </label>
 

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -60,6 +60,7 @@ const [email, setEmail] = useState("");
       navigate("/");
     } catch (err) { 
       console.error("로그인 에러:", err);
+       setErrorMessage(err.message);
     }
   };
 

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -300,8 +300,8 @@ const Signup = () => {
           </button>
         </form>
         <div className="flex mt-4 text-xl cursor-pointer divide-x divide-white">
-        <Link className="underline  px-10" to='/signin'>LOGIN</Link>
-        <Link className=" underline px-10" to='/'>HOME</Link>
+        <Link className="px-10" to='/signin'>LOGIN</Link>
+        <Link className="px-10" to='/'>HOME</Link>
 
         </div>
       </div>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { GoArrowLeft } from "react-icons/go";
 import signUpApi from "../apis/signUpApi";
 import emailCheckApi from "../apis/emailCheckApi";
@@ -168,13 +168,10 @@ const Signup = () => {
 
   return (
     <div className="text-white">
-      <button className="text-[55px] ml-[25px] mt-[18px]" type="button"
-      onClick={() => navigate(-1)}>
-        <GoArrowLeft />
-      </button>
+  
 
       <div className="flex flex-col items-center">
-        <span className="mt-[77px] text-[23px]">작은 별, 작은 감정의 조각</span>
+        <span className="mt-30 text-[23px]">작은 별, 작은 감정의 조각</span>
         <span className="text-[90px] font-julius mt-[2px]">STARLET</span>
 
         <form className="flex flex-col gap-[12px] text-[20px]" onSubmit={SignUpHandler}>
@@ -302,6 +299,11 @@ const Signup = () => {
             SIGNUP
           </button>
         </form>
+        <div className="flex mt-4 text-xl cursor-pointer divide-x divide-white">
+        <Link className="underline  px-10" to='/signin'>LOGIN</Link>
+        <Link className=" underline px-10" to='/'>HOME</Link>
+
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -24,7 +24,7 @@ const Signup = () => {
   const [emailLoading, setEmailLoading] = useState(false);
   const [emailInitSent, setEmailInitSent] = useState(false);
   const [emailVerified, setEmailVerified] = useState(false);
-
+  const [emailChecked, setEmailChecked] = useState(false);
 
   const [nicknameMsg, setNicknameMsg] = useState("");
 
@@ -88,11 +88,13 @@ const Signup = () => {
     
         await emailInitApi(v);
         setEmailInitSent(true);
+        setEmailChecked(true); 
         setEmailMsg("인증 메일을 보냈습니다. 메일함에서 인증을 완료한 뒤, 아래 '인증 완료'를 눌러주세요.");
         setEmailMsgColor("#54C65B");
       } else {
 
         setEmailInitSent(false);
+        setEmailChecked(false);
         setEmailMsg("중복된 이메일입니다.");
         setEmailMsgColor("#FF0000");
       }
@@ -162,6 +164,7 @@ const Signup = () => {
   };
 
   const isPwValid = password.length >= 6 && password.length <= 15;
+  const isNicknameValid = nickname.length >= 2 && nickname.length <= 10
 
   return (
     <div className="text-white">
@@ -182,6 +185,7 @@ const Signup = () => {
                 value={email}
                 onChange={(e) => {
                   setEmail(e.target.value);
+                  setEmailChecked(false);
                   if (!emailVerified) setEmailMsg("");
                 }}
                 placeholder="이메일 주소"
@@ -192,7 +196,7 @@ const Signup = () => {
                 className="border rounded-[5px] w-[111px] h-[66px] text-[20px] hover:bg-[#3E33DB] hover:text-white disabled:opacity-60"
                 onClick={handleEmailCheck}
                 type="button"
-                disabled={emailLoading || emailVerified}
+                disabled={emailLoading || emailVerified || emailChecked}
               >
                 {emailLoading ? "발송중..." : "중복 확인"}
               </button>
@@ -233,10 +237,18 @@ const Signup = () => {
                 className="border rounded-[5px] hover:bg-[#3E33DB] hover:text-white w-[111px] h-[66px] text-[20px]"
                 onClick={handleNicknameCheck}
                 type="button"
+                 disabled={!isNicknameValid} 
               >
                 중복 확인
               </button>
             </div>
+          <div className="h-[1px] leading-[18px] text-[13px]">
+   {nickname && !isNicknameValid ? (
+     <span className="text-[#FF0000]">닉네임은 2~10글자 이내여야합니다.</span>
+   ) : (
+     "\u00A0"
+   )}
+ </div>
             <div className="h-[18px] leading-[18px] text-[13px]">
               {nicknameMsg ? (
                 <span className={nicknameMsg.includes("사용 가능") ? "text-[#54C65B]" : "text-[#FF0000]"}>{nicknameMsg}</span>


### PR DESCRIPTION
## PR 요약
- 로그인 오류 메시지 수정 및 한영 토글 구현

## 작업사항
- 로그인 시 해당 오류(ex. 비밀번호 미기재, 아이디 or 비밀번호 형식 맞지않음) 에 대한 메시지를 ui에 나타나도록 수정
- 로그인 유지 체크박스 및 텍스트 삭제
- 회원가입 페이지 뒤로가기 삭제 후 홈화면, 로그인화면 이동 추가
- 한/영 전환 토글 구현 (아래 사진 참고) 
<img width="452" height="249" alt="image" src="https://github.com/user-attachments/assets/e43eb96b-85f5-4db0-8867-fb98313f87b1" />
