### PR TITLE
Fix/constellation : 밤하늘 페이지 오류 및 기능 추가

### DIFF
--- a/src/components/ConstellationModal.jsx
+++ b/src/components/ConstellationModal.jsx
@@ -1,31 +1,50 @@
 import React, { useEffect, useRef, useState } from "react";
 
+import backgroundImg from "../assets/background.png";
+
 const MIN_NODES = 7;
+
 const MAX_NODES = 14;
+
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
 
 const ConstellationModal = ({
   open,
+
   onClose,
+
   onSubmit,
+
   initial,
+
   stars = [],
+
   colorImageMap = {},
 }) => {
+  const [step, setStep] = useState(1); // 1: 선 잇기, 2: 이름/소개
+
   const [name, setName] = useState(initial?.name ?? "");
+
   const [desc, setDesc] = useState(initial?.desc ?? "");
+
   const [starPositions, setStarPositions] = useState({});
+
   const [edges, setEdges] = useState([]);
+
   const [selectedStar, setSelectedStar] = useState(null);
+
   const [warn, setWarn] = useState("");
 
   const panelRef = useRef(null);
+
   const dragIdRef = useRef(null);
 
-  const clamp01 = (v) => Math.max(0, Math.min(1, v));
   const toRel = (clientX, clientY) => {
     const r = panelRef.current.getBoundingClientRect();
+
     return {
       x: clamp01((clientX - r.left) / r.width),
+
       y: clamp01((clientY - r.top) / r.height),
     };
   };
@@ -33,22 +52,32 @@ const ConstellationModal = ({
   useEffect(() => {
     if (!open) return;
 
+    setStep(1);
+
     setName(initial?.name ?? "");
+
     setDesc(initial?.desc ?? "");
+
     setWarn("");
 
     const init = {};
+
     (stars || []).forEach((s) => {
       init[s.id] = {
         x: typeof s.x === "number" ? clamp01(s.x) : 0.5,
+
         y: typeof s.y === "number" ? clamp01(s.y) : 0.5,
       };
     });
+
     setStarPositions(init);
-    setEdges([]);
+
+    setEdges(initial?.lines ?? []);
+
     setSelectedStar(null);
 
     document.body.style.overflow = "hidden";
+
     return () => {
       document.body.style.overflow = "";
     };
@@ -57,51 +86,48 @@ const ConstellationModal = ({
   useEffect(() => {
     return () => {
       window.removeEventListener("pointermove", onPointerMove);
+
       window.removeEventListener("pointerup", onPointerUp);
     };
   }, []);
 
   const onPointerDownStar = (e, id) => {
+    if (step !== 1) return;
+
     e.preventDefault();
+
     e.stopPropagation();
+
     setWarn("");
+
     dragIdRef.current = id;
+
     window.addEventListener("pointermove", onPointerMove, { passive: false });
+
     window.addEventListener("pointerup", onPointerUp, { passive: true });
   };
 
   const onPointerMove = (e) => {
-    if (!dragIdRef.current || !panelRef.current) return;
+    if (!dragIdRef.current || !panelRef.current || step !== 1) return;
+
     e.preventDefault();
+
     const { x, y } = toRel(e.clientX, e.clientY);
+
     const id = dragIdRef.current;
+
     setStarPositions((prev) => ({ ...prev, [id]: { x, y } }));
   };
 
   const onPointerUp = () => {
     dragIdRef.current = null;
+
     window.removeEventListener("pointermove", onPointerMove);
+
     window.removeEventListener("pointerup", onPointerUp);
   };
 
-  const willFormCycle = (a, b, currentEdges) => {
-    const parent = {};
-    const find = (x) => {
-      if (parent[x] == null) parent[x] = x;
-      if (parent[x] === x) return x;
-      parent[x] = find(parent[x]);
-      return parent[x];
-    };
-    const union = (x, y) => {
-      const rx = find(x);
-      const ry = find(y);
-      if (rx === ry) return false;
-      parent[ry] = rx;
-      return true;
-    };
-    for (const [u, v] of currentEdges) union(u, v);
-    return find(a) === find(b);
-  };
+  // 사이클 허용
 
   const addEdgeIfValid = (a, b) => {
     if (a === b) return;
@@ -109,62 +135,90 @@ const ConstellationModal = ({
     const exists = edges.some(
       ([u, v]) => (u === a && v === b) || (u === b && v === a)
     );
+
     if (exists) return;
 
-    if (willFormCycle(a, b, edges)) {
-      setWarn("선이 순환(사이클)되면 안 돼요. 다른 별을 선택해보세요.");
-      return;
-    }
-
     const nodeSet = new Set(edges.flat());
+
     nodeSet.add(a);
+
     nodeSet.add(b);
+
     if (nodeSet.size > MAX_NODES) {
       setWarn(`연결된 별은 최대 ${MAX_NODES}개까지예요.`);
+
       return;
     }
 
     setEdges((prev) => [...prev, [a, b]]);
+
     setWarn("");
+
+    setSelectedStar(null); // 선 추가 후 선택 해제
   };
 
   const onClickStar = (id) => {
+    if (step !== 1) return;
+
     if (!selectedStar) {
       setSelectedStar(id);
+
       setWarn("");
+
       return;
     }
+
     if (selectedStar === id) {
       setSelectedStar(null);
+
       return;
     }
+
     addEdgeIfValid(selectedStar, id);
-    setSelectedStar(null);
   };
 
   const removeLastLine = () => {
     setWarn("");
+
     setEdges((prev) => prev.slice(0, -1));
   };
 
   const clearLines = () => {
     setWarn("");
+
     setEdges([]);
   };
 
-  const submit = () => {
-    const nodeSet = new Set(edges.flat());
-    const cnt = nodeSet.size;
-    if (cnt < MIN_NODES || cnt > MAX_NODES) {
+  const nodeCount = new Set(edges.flat()).size;
+
+  const goNext = () => {
+    if (nodeCount < MIN_NODES || nodeCount > MAX_NODES) {
       setWarn(
-        `별자리는 연결된 별이 ${MIN_NODES}~${MAX_NODES}개여야 해요. (현재: ${cnt}개)`
+        `별자리는 연결된 별이 ${MIN_NODES}~${MAX_NODES}개여야 해요. (현재: ${nodeCount}개)`
       );
+
       return;
     }
+
+    setWarn("");
+
+    setSelectedStar(null);
+
+    setStep(2);
+  };
+
+  const canFinish = name.trim().length > 0 && desc.trim().length > 0;
+
+  const finish = () => {
+    if (!canFinish) return;
+
     onSubmit?.({
       name: name.trim(),
+
       desc: desc.trim(),
+
       lines: edges,
+
       starPositions,
     });
   };
@@ -177,166 +231,253 @@ const ConstellationModal = ({
       role="dialog"
       aria-modal="true"
       style={{
-        background:
-          "radial-gradient(circle at 10% 10%, rgba(255,255,255,0.12) 0%, rgba(5,21,48,1) 45%, rgba(5,21,48,1) 100%)",
+        background: "rgba(0,0,0,0.28)",
+
+        backdropFilter: "blur(2px)",
       }}
     >
-      <div
-        className="absolute inset-0"
-        onClick={onClose}
-        aria-hidden="true"
-        style={{ backdropFilter: "blur(1px)" }}
-      />
+      <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
 
       <div
-        className="relative w-[1180px] max-w-[95vw] h-[650px] rounded-[28px] shadow-[0_20px_60px_rgba(0,0,0,0.35)] border border-white/25 flex"
+        className="relative w-[950px] max-w-[96vw] rounded-[26px] flex flex-col"
         style={{
-          background:
-            "linear-gradient(180deg, rgba(246,247,250,0.3) 0%, rgba(237,239,242,0.35) 50%, rgba(232,233,236,0.2) 100%)",
-          backdropFilter: "blur(16px)",
+          backgroundColor: "#f3f4f6",
+
+          boxShadow: "0 14px 40px rgba(0,0,0,0.35)",
         }}
+        onClick={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={onClose}
-          className="absolute right-8 top-7 text-black/70 hover:text-black text-3xl"
-          aria-label="닫기"
+        {/* 상단 헤더 */}
+
+        <div
+          className="flex items-center justify-between px-7 h-[64px] rounded-t-[26px]"
+          style={{
+            backgroundColor: "#e4e5e7",
+
+            borderBottom: "1px solid rgba(0,0,0,0.08)",
+          }}
         >
-          ←
-        </button>
+          <button
+            onClick={() => {
+              if (step === 1) onClose?.();
+              else {
+                setStep(1);
 
-        <div className="w-[48%] h-full flex flex-col px-7 py-6">
-          <div
-            ref={panelRef}
-            className="relative flex-1 rounded-[20px] bg-[#dcdfe5]/60 border-[3px] border-[#b7b4b7]/80 overflow-hidden"
-            style={{
-              backgroundImage:
-                "radial-gradient(circle, rgba(255,255,255,0.25) 1px, transparent 1px)",
-              backgroundSize: "60px 60px",
-              boxShadow: "inset 0 0 20px rgba(0,0,0,0.05)",
-              touchAction: "none",
+                setWarn("");
+
+                setSelectedStar(null);
+              }
             }}
+            className="text-[24px] text-black/70 hover:text-black leading-none"
           >
-            <svg className="absolute inset-0 w-full h-full pointer-events-none">
-              {edges.map(([a, b], idx) => {
-                const pa = starPositions[a];
-                const pb = starPositions[b];
-                if (!pa || !pb) return null;
-                return (
-                  <line
-                    key={idx}
-                    x1={`${pa.x * 100}%`}
-                    y1={`${pa.y * 100}%`}
-                    x2={`${pb.x * 100}%`}
-                    y2={`${pb.y * 100}%`}
-                    stroke="#000000"
-                    strokeOpacity="0.9"
-                    strokeWidth="2.3"
-                    strokeLinecap="round"
-                  />
-                );
-              })}
-            </svg>
+            {step === 1 ? "×" : "←"}
+          </button>
 
-            {stars.map((s) => {
-              const p = starPositions[s.id];
-              if (!p) return null;
-              const imgSrc = colorImageMap[s.color];
-              if (!imgSrc) return null;
-              const selected = selectedStar === s.id;
-              return (
-                <img
-                  key={s.id}
-                  src={imgSrc}
-                  alt={s.color}
-                  draggable={false}
-                  onPointerDown={(e) => onPointerDownStar(e, s.id)}
-                  onClick={() => onClickStar(s.id)}
-                  style={{
-                    position: "absolute",
-                    left: `${p.x * 100}%`,
-                    top: `${p.y * 100}%`,
-                    transform: "translate(-50%, -50%)",
-                    width: 24,
-                    height: 24,
-                    userSelect: "none",
-                    touchAction: "none",
-                    cursor: "grab",
-                    filter: selected
-                      ? "drop-shadow(0 0 6px rgba(17,24,39,.6))"
-                      : "none",
-                  }}
-                />
-              );
-            })}
+          <div className="text-[20px] font-semibold text-black">
+            별자리 생성
           </div>
 
-          <div className="mt-3 flex items-center justify-between gap-3">
-            <p className="text-[13px] text-black/65">
-              별을 끌어 이동하고, 서로 클릭해 선을 이어보세요.
-            </p>
-            <div className="flex gap-2">
-              <button
-                onClick={removeLastLine}
-                disabled={edges.length === 0}
-                className={`px-3 py-1.5 text-[12px] rounded-lg border ${
-                  edges.length === 0
-                    ? "bg-white/60 text-black/30 border-black/5"
-                    : "bg-white/90 text-black/70 hover:bg-white border-black/10"
-                }`}
-              >
-                마지막 선 지우기
-              </button>
-              <button
-                onClick={clearLines}
-                disabled={edges.length === 0}
-                className={`px-3 py-1.5 text-[12px] rounded-lg border ${
-                  edges.length === 0
-                    ? "bg-white/60 text-black/30 border-black/5"
-                    : "bg-white/90 text-black/70 hover:bg-white border-black/10"
-                }`}
-              >
-                전체 선 지우기
-              </button>
-            </div>
-          </div>
-
-          {warn && (
-            <div className="mt-2 text-[12px] text-red-700 bg-red-50/80 border border-red-200 px-3 py-2 rounded-lg">
-              {warn}
-            </div>
+          {step === 1 ? (
+            <button
+              onClick={goNext}
+              className="text-[15px] font-semibold text-[#111827]"
+            >
+              다음
+            </button>
+          ) : (
+            <button
+              onClick={finish}
+              disabled={!canFinish}
+              className={`text-[15px] font-semibold ${
+                canFinish
+                  ? "text-[#111827]"
+                  : "text-black/30 cursor-not-allowed"
+              }`}
+            >
+              완료
+            </button>
           )}
         </div>
 
-        <div className="w-[52%] h-full flex flex-col items-center justify-center px-10 gap-6">
-          <h2 className="text-[30px] font-extrabold text-black tracking-tight text-center">
-            별자리 이름을 지정해주세요
-          </h2>
+        <div className="flex flex-col items-center px-10 py-6 gap-4">
+          {/* 안내문구: 1단계만 표시 */}
 
-          <div className="w-full flex flex-col gap-4 max-w-[460px]">
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="미지정 별자리"
-              className="w-full h-[54px] rounded-full bg-white/90 px-6 text-[15px] text-black outline-none border border-white/0 focus:border-[#146b5b]/50 shadow-[0_4px_18px_rgba(0,0,0,0.04)]"
-            />
+          {step === 1 && (
+            <p className="text-[13px] text-black/60">
+              *별을 끌어 이동하고, 서로 연결하여 별자리를 완성해보세요
+            </p>
+          )}
 
-            <input
-              type="text"
-              value={desc}
-              onChange={(e) => setDesc(e.target.value)}
-              placeholder="별자리에 대한 소개를 작성해주세요"
-              className="w-full h-[54px] rounded-full bg-white/90 px-6 text-[15px] text-black outline-none border border-white/0 focus:border-[#146b5b]/50 shadow-[0_4px_18px_rgba(0,0,0,0.04)]"
-            />
+          <div className="flex flex-col items-center gap-5">
+            {/* 별자리 패널 */}
+
+            <div
+              ref={panelRef}
+              className="relative w-[440px] max-w-full aspect-square rounded-[26px] overflow-hidden"
+              style={{
+                backgroundImage: `url(${backgroundImg})`,
+
+                backgroundSize: "cover",
+
+                backgroundPosition: "center",
+
+                border: "1px solid rgba(0,0,0,0.12)",
+              }}
+            >
+              <svg className="absolute inset-0 w-full h-full pointer-events-none">
+                {edges.map(([a, b], idx) => {
+                  const pa = starPositions[a];
+
+                  const pb = starPositions[b];
+
+                  if (!pa || !pb) return null;
+
+                  return (
+                    <line
+                      key={idx}
+                      x1={`${pa.x * 100}%`}
+                      y1={`${pa.y * 100}%`}
+                      x2={`${pb.x * 100}%`}
+                      y2={`${pb.y * 100}%`}
+                      stroke="#ffffff"
+                      strokeOpacity="0.95"
+                      strokeWidth="2.2"
+                      strokeLinecap="round"
+                    />
+                  );
+                })}
+              </svg>
+
+              {stars.map((s) => {
+                const p = starPositions[s.id];
+
+                if (!p) return null;
+
+                const imgSrc = colorImageMap[s.color];
+
+                if (!imgSrc) return null;
+
+                const isSelected = step === 1 && selectedStar === s.id;
+
+                return (
+                  <img
+                    key={s.id}
+                    src={imgSrc}
+                    alt={s.color}
+                    draggable={false}
+                    onPointerDown={(e) => onPointerDownStar(e, s.id)}
+                    onClick={() => onClickStar(s.id)}
+                    style={{
+                      position: "absolute",
+
+                      left: `${p.x * 100}%`,
+
+                      top: `${p.y * 100}%`,
+
+                      transform: "translate(-50%, -50%)",
+
+                      width: 22,
+
+                      height: 22,
+
+                      userSelect: "none",
+
+                      touchAction: "none",
+
+                      cursor: step === 1 ? "grab" : "default",
+
+                      filter: isSelected
+                        ? "drop-shadow(0 0 8px rgba(255,255,255,0.9))"
+                        : "none",
+
+                      animation: isSelected
+                        ? "twinkleStar 0.9s ease-in-out infinite alternate"
+                        : "none",
+
+                      pointerEvents: step === 1 ? "auto" : "none",
+                    }}
+                  />
+                );
+              })}
+            </div>
+
+            {/* 1단계 버튼 */}
+
+            {step === 1 && (
+              <div className="flex gap-3">
+                <button
+                  onClick={clearLines}
+                  disabled={edges.length === 0}
+                  className={`px-5 py-2 rounded-[999px] text-[13px] ${
+                    edges.length === 0
+                      ? "bg-[#e5e7eb] text-black/35 cursor-not-allowed"
+                      : "bg-[#e5e7eb] text-black/70 hover:bg-[#d4d7dd]"
+                  }`}
+                >
+                  전체 삭제
+                </button>
+
+                <button
+                  onClick={removeLastLine}
+                  disabled={edges.length === 0}
+                  className={`px-5 py-2 rounded-[999px] text-[13px] ${
+                    edges.length === 0
+                      ? "bg-[#e5e7eb] text-black/35 cursor-not-allowed"
+                      : "bg-[#e5e7eb] text-black/70 hover:bg-[#d4d7dd]"
+                  }`}
+                >
+                  마지막 선 지우기
+                </button>
+              </div>
+            )}
+
+            {/* 2단계 입력 */}
+
+            {step === 2 && (
+              <div className="flex flex-col items-center w-full gap-4">
+                <h2 className="text-[17px] font-semibold text-black/80">
+                  별자리 이름을 지정해주세요
+                </h2>
+
+                <div className="w-[380px] flex flex-col gap-3">
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="미지정 별자리"
+                    className="w-full h-[44px] rounded-full bg-white px-5 text-[14px] text-black outline-none border border-black/10 focus:border-[#4b5563]"
+                  />
+
+                  <input
+                    type="text"
+                    value={desc}
+                    onChange={(e) => setDesc(e.target.value)}
+                    placeholder="별자리에 대한 소개를 작성해주세요"
+                    className="w-full h-[44px] rounded-full bg-white px-5 text-[14px] text-black outline-none border border-black/10 focus:border-[#4b5563]"
+                  />
+                </div>
+              </div>
+            )}
+
+            {warn && (
+              <div className="text-[12px] text-red-700 bg-red-50/80 border border-red-200 px-3 py-2 rounded-lg">
+                {warn}
+              </div>
+            )}
           </div>
-
-          <button
-            onClick={submit}
-            className="mt-2 px-16 py-2.5 rounded-[9999px] bg-[#12561f] hover:bg-[#0f491a] text-white font-semibold tracking-[0.4em]"
-          >
-            설 정
-          </button>
         </div>
+
+        <style>{`
+
+@keyframes twinkleStar {
+
+0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+
+100% { transform: translate(-50%, -50%) scale(1.1); opacity: 0.6; }
+
+}
+
+`}</style>
       </div>
     </div>
   );

--- a/src/components/ConstellationModal.jsx
+++ b/src/components/ConstellationModal.jsx
@@ -3,48 +3,32 @@ import React, { useEffect, useRef, useState } from "react";
 import backgroundImg from "../assets/background.png";
 
 const MIN_NODES = 7;
-
 const MAX_NODES = 14;
-
 const clamp01 = (v) => Math.max(0, Math.min(1, v));
 
 const ConstellationModal = ({
   open,
-
   onClose,
-
   onSubmit,
-
   initial,
-
   stars = [],
-
   colorImageMap = {},
 }) => {
-  const [step, setStep] = useState(1); // 1: 선 잇기, 2: 이름/소개
-
+  const [step, setStep] = useState(1);
   const [name, setName] = useState(initial?.name ?? "");
-
   const [desc, setDesc] = useState(initial?.desc ?? "");
-
   const [starPositions, setStarPositions] = useState({});
-
   const [edges, setEdges] = useState([]);
-
   const [selectedStar, setSelectedStar] = useState(null);
-
   const [warn, setWarn] = useState("");
 
   const panelRef = useRef(null);
-
   const dragIdRef = useRef(null);
 
   const toRel = (clientX, clientY) => {
     const r = panelRef.current.getBoundingClientRect();
-
     return {
       x: clamp01((clientX - r.left) / r.width),
-
       y: clamp01((clientY - r.top) / r.height),
     };
   };
@@ -53,31 +37,23 @@ const ConstellationModal = ({
     if (!open) return;
 
     setStep(1);
-
     setName(initial?.name ?? "");
-
     setDesc(initial?.desc ?? "");
-
     setWarn("");
 
     const init = {};
-
     (stars || []).forEach((s) => {
       init[s.id] = {
         x: typeof s.x === "number" ? clamp01(s.x) : 0.5,
-
         y: typeof s.y === "number" ? clamp01(s.y) : 0.5,
       };
     });
 
     setStarPositions(init);
-
     setEdges(initial?.lines ?? []);
-
     setSelectedStar(null);
 
     document.body.style.overflow = "hidden";
-
     return () => {
       document.body.style.overflow = "";
     };
@@ -86,34 +62,26 @@ const ConstellationModal = ({
   useEffect(() => {
     return () => {
       window.removeEventListener("pointermove", onPointerMove);
-
       window.removeEventListener("pointerup", onPointerUp);
     };
   }, []);
 
   const onPointerDownStar = (e, id) => {
     if (step !== 1) return;
-
     e.preventDefault();
-
     e.stopPropagation();
-
     setWarn("");
 
     dragIdRef.current = id;
-
     window.addEventListener("pointermove", onPointerMove, { passive: false });
-
     window.addEventListener("pointerup", onPointerUp, { passive: true });
   };
 
   const onPointerMove = (e) => {
     if (!dragIdRef.current || !panelRef.current || step !== 1) return;
-
     e.preventDefault();
 
     const { x, y } = toRel(e.clientX, e.clientY);
-
     const id = dragIdRef.current;
 
     setStarPositions((prev) => ({ ...prev, [id]: { x, y } }));
@@ -121,13 +89,9 @@ const ConstellationModal = ({
 
   const onPointerUp = () => {
     dragIdRef.current = null;
-
     window.removeEventListener("pointermove", onPointerMove);
-
     window.removeEventListener("pointerup", onPointerUp);
   };
-
-  // 사이클 허용
 
   const addEdgeIfValid = (a, b) => {
     if (a === b) return;
@@ -135,26 +99,20 @@ const ConstellationModal = ({
     const exists = edges.some(
       ([u, v]) => (u === a && v === b) || (u === b && v === a)
     );
-
     if (exists) return;
 
     const nodeSet = new Set(edges.flat());
-
     nodeSet.add(a);
-
     nodeSet.add(b);
 
     if (nodeSet.size > MAX_NODES) {
       setWarn(`연결된 별은 최대 ${MAX_NODES}개까지예요.`);
-
       return;
     }
 
     setEdges((prev) => [...prev, [a, b]]);
-
     setWarn("");
-
-    setSelectedStar(null); // 선 추가 후 선택 해제
+    setSelectedStar(null);
   };
 
   const onClickStar = (id) => {
@@ -162,15 +120,12 @@ const ConstellationModal = ({
 
     if (!selectedStar) {
       setSelectedStar(id);
-
       setWarn("");
-
       return;
     }
 
     if (selectedStar === id) {
       setSelectedStar(null);
-
       return;
     }
 
@@ -179,13 +134,11 @@ const ConstellationModal = ({
 
   const removeLastLine = () => {
     setWarn("");
-
     setEdges((prev) => prev.slice(0, -1));
   };
 
   const clearLines = () => {
     setWarn("");
-
     setEdges([]);
   };
 
@@ -196,14 +149,11 @@ const ConstellationModal = ({
       setWarn(
         `별자리는 연결된 별이 ${MIN_NODES}~${MAX_NODES}개여야 해요. (현재: ${nodeCount}개)`
       );
-
       return;
     }
 
     setWarn("");
-
     setSelectedStar(null);
-
     setStep(2);
   };
 
@@ -212,14 +162,15 @@ const ConstellationModal = ({
   const finish = () => {
     if (!canFinish) return;
 
+    const createdAt =
+      initial?.constellationCreatedAt || new Date().toISOString();
+
     onSubmit?.({
       name: name.trim(),
-
       desc: desc.trim(),
-
       lines: edges,
-
       starPositions,
+      constellationCreatedAt: createdAt,
     });
   };
 
@@ -232,7 +183,6 @@ const ConstellationModal = ({
       aria-modal="true"
       style={{
         background: "rgba(0,0,0,0.28)",
-
         backdropFilter: "blur(2px)",
       }}
     >
@@ -242,18 +192,14 @@ const ConstellationModal = ({
         className="relative w-[950px] max-w-[96vw] rounded-[26px] flex flex-col"
         style={{
           backgroundColor: "#f3f4f6",
-
           boxShadow: "0 14px 40px rgba(0,0,0,0.35)",
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* 상단 헤더 */}
-
         <div
           className="flex items-center justify-between px-7 h-[64px] rounded-t-[26px]"
           style={{
             backgroundColor: "#e4e5e7",
-
             borderBottom: "1px solid rgba(0,0,0,0.08)",
           }}
         >
@@ -262,9 +208,7 @@ const ConstellationModal = ({
               if (step === 1) onClose?.();
               else {
                 setStep(1);
-
                 setWarn("");
-
                 setSelectedStar(null);
               }
             }}
@@ -300,8 +244,6 @@ const ConstellationModal = ({
         </div>
 
         <div className="flex flex-col items-center px-10 py-6 gap-4">
-          {/* 안내문구: 1단계만 표시 */}
-
           {step === 1 && (
             <p className="text-[13px] text-black/60">
               *별을 끌어 이동하고, 서로 연결하여 별자리를 완성해보세요
@@ -309,27 +251,20 @@ const ConstellationModal = ({
           )}
 
           <div className="flex flex-col items-center gap-5">
-            {/* 별자리 패널 */}
-
             <div
               ref={panelRef}
               className="relative w-[440px] max-w-full aspect-square rounded-[26px] overflow-hidden"
               style={{
                 backgroundImage: `url(${backgroundImg})`,
-
                 backgroundSize: "cover",
-
                 backgroundPosition: "center",
-
                 border: "1px solid rgba(0,0,0,0.12)",
               }}
             >
               <svg className="absolute inset-0 w-full h-full pointer-events-none">
                 {edges.map(([a, b], idx) => {
                   const pa = starPositions[a];
-
                   const pb = starPositions[b];
-
                   if (!pa || !pb) return null;
 
                   return (
@@ -350,11 +285,9 @@ const ConstellationModal = ({
 
               {stars.map((s) => {
                 const p = starPositions[s.id];
-
                 if (!p) return null;
 
                 const imgSrc = colorImageMap[s.color];
-
                 if (!imgSrc) return null;
 
                 const isSelected = step === 1 && selectedStar === s.id;
@@ -369,39 +302,26 @@ const ConstellationModal = ({
                     onClick={() => onClickStar(s.id)}
                     style={{
                       position: "absolute",
-
                       left: `${p.x * 100}%`,
-
                       top: `${p.y * 100}%`,
-
                       transform: "translate(-50%, -50%)",
-
                       width: 22,
-
                       height: 22,
-
                       userSelect: "none",
-
                       touchAction: "none",
-
                       cursor: step === 1 ? "grab" : "default",
-
                       filter: isSelected
                         ? "drop-shadow(0 0 8px rgba(255,255,255,0.9))"
                         : "none",
-
                       animation: isSelected
                         ? "twinkleStar 0.9s ease-in-out infinite alternate"
                         : "none",
-
                       pointerEvents: step === 1 ? "auto" : "none",
                     }}
                   />
                 );
               })}
             </div>
-
-            {/* 1단계 버튼 */}
 
             {step === 1 && (
               <div className="flex gap-3">
@@ -430,8 +350,6 @@ const ConstellationModal = ({
                 </button>
               </div>
             )}
-
-            {/* 2단계 입력 */}
 
             {step === 2 && (
               <div className="flex flex-col items-center w-full gap-4">
@@ -468,16 +386,11 @@ const ConstellationModal = ({
         </div>
 
         <style>{`
-
-@keyframes twinkleStar {
-
-0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
-
-100% { transform: translate(-50%, -50%) scale(1.1); opacity: 0.6; }
-
-}
-
-`}</style>
+          @keyframes twinkleStar {
+            0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+            100% { transform: translate(-50%, -50%) scale(1.1); opacity: 0.6; }
+          }
+        `}</style>
       </div>
     </div>
   );

--- a/src/components/StarSkyDate.jsx
+++ b/src/components/StarSkyDate.jsx
@@ -23,6 +23,61 @@ const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 const EDGE_PAD = 0.02;
 const LABEL_TOP_FLIP_Y = 0.1;
 
+// 별이 UI 버튼/아이콘 영역 안으로 못 들어가게 하기 위한 헬퍼
+function avoidUiZones(nx, ny, rect) {
+  if (!rect) return { x: nx, y: ny };
+  let px = nx * rect.width;
+  let py = ny * rect.height;
+
+  const zones = [
+    // 좌측 상단 햄버거 메뉴 – 살짝 더 작은 영역
+    { x1: 0, y1: 0, x2: 60, y2: 65 },
+
+    // 우측 상단 GENERATE 버튼 – 좌우/세로 조금 줄이기
+    { x1: rect.width - 115, y1: 0, x2: rect.width, y2: 50 },
+
+    // 하단 월 이동 바 – 좌우/위쪽 약간 줄이기
+    {
+      x1: rect.width / 2 - 160,
+      y1: rect.height - 80,
+      x2: rect.width / 2 + 160,
+      y2: rect.height,
+    },
+  ];
+
+  const margin = 4; // 바깥으로 살짝 밀어낼 여유
+
+  zones.forEach((z) => {
+    if (px >= z.x1 && px <= z.x2 && py >= z.y1 && py <= z.y2) {
+      // 네 변까지의 거리 계산
+      const dLeft = px - z.x1;
+      const dRight = z.x2 - px;
+      const dTop = py - z.y1;
+      const dBottom = z.y2 - py;
+
+      const minD = Math.min(dLeft, dRight, dTop, dBottom);
+
+      if (minD === dLeft) {
+        // 왼쪽 벽이 제일 가까우면 왼쪽으로 밀기
+        px = z.x1 - margin;
+      } else if (minD === dRight) {
+        // 오른쪽 벽이 제일 가까우면 오른쪽으로 밀기
+        px = z.x2 + margin;
+      } else if (minD === dTop) {
+        // 위쪽이 제일 가까우면 위로 밀기
+        py = z.y1 - margin;
+      } else {
+        // 아래쪽이 제일 가까우면 아래로 밀기
+        py = z.y2 + margin;
+      }
+    }
+  });
+
+  const nx2 = clampToView(px / rect.width);
+  const ny2 = clampToView(py / rect.height);
+  return { x: nx2, y: ny2 };
+}
+
 function getTodayLocal() {
   const d = new Date();
   const y = d.getFullYear();
@@ -171,29 +226,28 @@ export default function StarSkyDate({
 
   const constellationCreatedAtRef = useRef({});
 
+  // 라벨 날짜: 모달에서 생성 완료한 날짜만 사용, 없으면 새로 오늘로 채우지 않음
   useEffect(() => {
     if (!filteredConstellationGroups.length) return;
     const store = constellationCreatedAtRef.current;
-    const today = getTodayLocal();
 
     filteredConstellationGroups.forEach((g) => {
       const id = g.id;
       if (!id) return;
 
       const modalPickedDate =
-        g.constellationDate || g.selectedDate || g.dateFromModal || null;
+        g.constellationCreatedAt ||
+        g.constellationDate ||
+        g.selectedDate ||
+        g.dateFromModal ||
+        g.createdAt ||
+        g.created_at ||
+        null;
 
-      if (!store[id]) {
-        if (modalPickedDate) {
-          store[id] = String(modalPickedDate).slice(0, 10);
-        } else {
-          store[id] = today;
-        }
-      } else {
-        if (modalPickedDate) {
-          store[id] = String(modalPickedDate).slice(0, 10);
-        }
+      if (modalPickedDate) {
+        store[id] = String(modalPickedDate).slice(0, 10);
       }
+      // modalPickedDate가 없으면 아무것도 하지 않음 (기존 값 유지, 없으면 undefined)
     });
   }, [filteredConstellationGroups]);
 
@@ -205,7 +259,7 @@ export default function StarSkyDate({
   const [starDrag, setStarDrag] = useState(null);
   const [hover, setHover] = useState({ show: false, x: 0, y: 0 });
 
-  const [scaleUI, setScaleUI] = useState(0.5);
+  const [scaleUI, setScaleUI] = useState(1.0);
   const scaleRef = useRef(1);
   const didInitialScaleRef = useRef(false);
   const committedMapRef = useRef(null);
@@ -244,29 +298,86 @@ export default function StarSkyDate({
     prevMultipleRef.current = multipleMode;
   }, [multipleMode]);
 
+  // 여러 별자리 기본 크기 통일을 위한 기준 크기 / 정규화 여부
+  const multiBaseSizeRef = useRef(null); // 기준 별자리(최고자리)의 크기
+  const multiNormalizedRef = useRef({}); // id -> boolean
+
+  // 여러 별자리(그룹) 기본 크기 통일 + 초기 위치 세팅
   useEffect(() => {
     if (!multipleMode) return;
+
+    let changed = false;
+    const baseStore = baseConstShapesRef.current;
+    const normalized = multiNormalizedRef.current;
+
     filteredConstellationGroups.forEach((g) => {
       const id = g.id;
       if (!id) return;
-      if (!baseConstShapesRef.current[id]) {
+
+      // 1) id별 base shape 없으면 한 번 만들기
+      if (!baseStore[id]) {
         const base = {};
         (g.stars || []).forEach((s) => {
           const realId = s.id ?? s.starId;
           base[realId] = { x: s.x, y: s.y };
         });
-        baseConstShapesRef.current[id] = ensureMinSize(base, 0.12);
+        const normalizedBase = ensureMinSize(base, 0.12);
+        baseStore[id] = normalizedBase;
+        changed = true;
+      }
+
+      const base = baseStore[id];
+      const box = computeBBoxFromPoints(Object.values(base));
+      if (!box) return;
+
+      // 2) 기준 크기(targetSize) 없으면 첫 번째 별자리 크기로 설정
+      if (multiBaseSizeRef.current == null) {
+        multiBaseSizeRef.current = Math.max(box.w, box.h);
+      }
+
+      const targetSize = multiBaseSizeRef.current;
+      const curSize = Math.max(box.w, box.h) || 0.0001;
+      const factor = targetSize / curSize;
+
+      // 3) 아직 이 id는 기준 크기로 정규화 안 했으면, 기준 크기에 맞게 스케일
+      if (!normalized[id]) {
+        let scaled = base;
+        if (Math.abs(factor - 1) > 1e-3) {
+          const scaledMap = {};
+          Object.entries(base).forEach(([starId, p]) => {
+            const dx = p.x - box.cx;
+            const dy = p.y - box.cy;
+            scaledMap[starId] = {
+              x: box.cx + dx * factor,
+              y: box.cy + dy * factor,
+            };
+          });
+          scaled = scaledMap;
+        }
+
+        baseStore[id] = scaled;
+        normalized[id] = true;
+
+        if (!appliedMapRef.current[id]) {
+          appliedMapRef.current[id] = deepClone(scaled);
+        }
+        changed = true;
       }
     });
+
+    if (changed) {
+      setAppliedVersion((v) => v + 1);
+    }
   }, [multipleMode, filteredConstellationGroups]);
 
+  // 현재 별의 실제 위치 얻기 (단일 별자리용)
   const positionOf = (s) => {
+    if (previewMap && previewMap[s.id]) {
+      return previewMap[s.id];
+    }
     const appliedSingle = appliedMapRef.current["single"];
     if (appliedSingle && appliedSingle[s.id]) {
       return appliedSingle[s.id];
-    }
-    if (previewMap && previewMap[s.id]) {
-      return previewMap[s.id];
     }
     return { x: s.x, y: s.y };
   };
@@ -280,6 +391,7 @@ export default function StarSkyDate({
     [livePoints]
   );
 
+  // locked 되었을 때, 단일 별자리 기본 스케일 적용 (항상 x1.0)
   useEffect(() => {
     if (multipleMode) {
       didInitialScaleRef.current = false;
@@ -295,15 +407,32 @@ export default function StarSkyDate({
       );
       const base = ensureMinSize(baseRaw, 0.12);
 
-      committedMapRef.current = base;
-      appliedMapRef.current["single"] = base;
-      scaleRef.current = 1;
-      singleScaleOriginRef.current = null;
-      setScaleUI(initialScaleOnLock);
-      applyScalePreviewSingle(initialScaleOnLock, {
-        commit: true,
-        forceFromScale: 1,
-      });
+      singleScaleOriginRef.current = base;
+      const clampedInit = 1.0; // 항상 x1.0을 기본으로
+      scaleRef.current = clampedInit;
+      setScaleUI(clampedInit);
+
+      const baseBox = computeBBoxFromPoints(Object.values(base));
+      let initialMap = base;
+      if (baseBox) {
+        const { cx, cy } = baseBox;
+        const sAbs = clampedInit;
+        initialMap = {};
+        Object.entries(base).forEach(([id, p]) => {
+          const dx = p.x - cx;
+          const dy = p.y - cy;
+          initialMap[id] = {
+            x: cx + dx * sAbs,
+            y: cy + dy * sAbs,
+          };
+        });
+        initialMap = fitMapIntoView(initialMap, 0);
+      }
+
+      appliedMapRef.current["single"] = initialMap;
+      setPreviewMap(null);
+      onTransform?.(initialMap);
+      onTransformEnd?.(initialMap);
       setIsSelected(false);
       setAppliedVersion((v) => v + 1);
     }
@@ -313,7 +442,7 @@ export default function StarSkyDate({
       committedMapRef.current = null;
       setPreviewMap(null);
       setIsSelected(false);
-      setScaleUI(0.5);
+      setScaleUI(1.0);
       scaleRef.current = 1;
       appliedMapRef.current = {};
       singleScaleOriginRef.current = null;
@@ -329,6 +458,8 @@ export default function StarSkyDate({
     initialScaleOnLock,
     filteredConstellationGroups,
     multipleMode,
+    onTransform,
+    onTransformEnd,
   ]);
 
   const toRel = (clientX, clientY) => {
@@ -339,6 +470,35 @@ export default function StarSkyDate({
     };
   };
 
+  // 멀티 모드에서 "현재 화면에 보이는" 별자리 맵을 얻기 위한 헬퍼
+  const getConstellationMapForDrag = (constellation) => {
+    const constId = constellation.id;
+    const appliedForThis = appliedMapRef.current[constId];
+    const baseMap = baseConstShapesRef.current[constId];
+    const usePreview = previewMap && constId === activeConstellationId;
+
+    const map = {};
+    (constellation.stars || []).forEach((s) => {
+      const key = s.id ?? s.starId;
+      let p = null;
+
+      if (usePreview && previewMap[key]) {
+        p = previewMap[key];
+      } else if (appliedForThis && appliedForThis[key]) {
+        p = appliedForThis[key];
+      } else if (baseMap && baseMap[key]) {
+        p = baseMap[key];
+      } else {
+        p = { x: s.x, y: s.y };
+      }
+
+      map[key] = { x: p.x, y: p.y };
+    });
+
+    return map;
+  };
+
+  // 단일 별자리 드래그 시작
   const startMoveDragSingle = (e) => {
     if (!locked || !liveBBox) return;
     e.preventDefault();
@@ -351,7 +511,6 @@ export default function StarSkyDate({
     const baseMap =
       previewMap ||
       appliedMapRef.current["single"] ||
-      committedMapRef.current ||
       Object.fromEntries(filteredStars.map((s) => [s.id, { x: s.x, y: s.y }]));
 
     groupDragRef.current = {
@@ -363,9 +522,6 @@ export default function StarSkyDate({
     };
 
     setIsSelected(true);
-    setPendingApply(true);
-    originalPositionRef.current = deepClone(baseMap);
-    singleScaleOriginRef.current = deepClone(baseMap);
   };
 
   const startMoveDragConstellation = (e, constellation) => {
@@ -375,38 +531,11 @@ export default function StarSkyDate({
     try {
       e.currentTarget?.setPointerCapture?.(e.pointerId);
     } catch {}
-    const startRel = toRel(e.clientX, e.clientY);
+
     const constId = constellation.id;
+    const startRel = toRel(e.clientX, e.clientY);
 
-    const previewForThis =
-      previewMap && constId === activeConstellationId ? previewMap : null;
-    const appliedForThis = appliedMapRef.current[constId];
-
-    let originMap = {};
-
-    if (previewForThis) {
-      Object.entries(previewForThis).forEach(([id, p]) => {
-        originMap[id] = { x: p.x, y: p.y };
-      });
-    } else if (appliedForThis) {
-      Object.entries(appliedForThis).forEach(([id, p]) => {
-        originMap[id] = { x: p.x, y: p.y };
-      });
-    } else if (committedConstMapRef.current[constId]) {
-      originMap = deepClone(committedConstMapRef.current[constId]);
-    } else {
-      (constellation.stars || []).forEach((s) => {
-        const realId = s.id || s.starId;
-        originMap[realId] = {
-          x: clampToView(s.x),
-          y: clampToView(s.y),
-        };
-      });
-      originMap = ensureMinSize(originMap, 0.12);
-    }
-
-    committedConstMapRef.current[constId] = deepClone(originMap);
-
+    const originMap = getConstellationMapForDrag(constellation);
     const bbox0 = computeBBoxFromPoints(Object.values(originMap));
 
     groupDragRef.current = {
@@ -464,11 +593,9 @@ export default function StarSkyDate({
 
     if (drag.mode === "single") {
       if (previewMap) {
-        singleScaleOriginRef.current = deepClone(previewMap);
-      } else if (appliedMapRef.current["single"]) {
-        singleScaleOriginRef.current = deepClone(
-          appliedMapRef.current["single"]
-        );
+        appliedMapRef.current["single"] = deepClone(previewMap);
+        onTransformEnd?.(previewMap);
+        setAppliedVersion((v) => v + 1);
       }
     } else if (drag.mode === "multi") {
       const constId = drag.constellationId;
@@ -498,8 +625,12 @@ export default function StarSkyDate({
 
     if (pendingApply) {
       if (originalPositionRef.current) {
+        appliedMapRef.current["single"] = deepClone(
+          originalPositionRef.current
+        );
         setPreviewMap(null);
         onTransformEnd?.(originalPositionRef.current);
+        setAppliedVersion((v) => v + 1);
       }
       setPendingApply(false);
     }
@@ -511,7 +642,12 @@ export default function StarSkyDate({
     try {
       e.currentTarget.setPointerCapture?.(e.pointerId);
     } catch {}
-    const cur = previewMap?.[star.id] ?? { x: star.x, y: star.y };
+    const cur = (previewMap && previewMap[star.id]) ||
+      (appliedMapRef.current["single"] &&
+        appliedMapRef.current["single"][star.id]) || {
+        x: star.x,
+        y: star.y,
+      };
     setStarDrag({
       id: star.id,
       startXpx: e.clientX,
@@ -532,11 +668,17 @@ export default function StarSkyDate({
     const moved =
       starDrag.moved || Math.hypot(dxPx, dyPx) >= DRAG_SELECT_THRESHOLD_PX;
 
-    const nx = clampToView(starDrag.originPos.x + dxPx / r.width);
-    const ny = clampToView(starDrag.originPos.y + dyPx / r.height);
+    let nx = clampToView(starDrag.originPos.x + dxPx / r.width);
+    let ny = clampToView(starDrag.originPos.y + dyPx / r.height);
+
+    // UI 버튼/아이콘 영역 안으로 못 들어가게 조정
+    const adjusted = avoidUiZones(nx, ny, r);
+    nx = adjusted.x;
+    ny = adjusted.y;
 
     const base =
-      previewMap ??
+      previewMap ||
+      appliedMapRef.current["single"] ||
       Object.fromEntries(filteredStars.map((s) => [s.id, { x: s.x, y: s.y }]));
     const next = { ...base, [star.id]: { x: nx, y: ny } };
 
@@ -577,8 +719,6 @@ export default function StarSkyDate({
     } else {
       if (previewMap) {
         appliedMapRef.current["single"] = deepClone(previewMap);
-        committedMapRef.current = deepClone(previewMap);
-        singleScaleOriginRef.current = deepClone(previewMap);
         setAppliedVersion((v) => v + 1);
       }
     }
@@ -586,53 +726,54 @@ export default function StarSkyDate({
     setStarDrag(null);
   };
 
-  const applyScalePreviewSingle = (
-    newScale,
-    { commit = false, forceFromScale } = {}
-  ) => {
-    const sAbs = Math.max(0.2, Math.min(1.0, newScale));
+  // 단일 별자리 크기 조절 (현재 상태 기준으로 스케일링)
+  const applyScalePreviewSingle = (newScale, { commit = false } = {}) => {
+    const sAbs = Math.max(0.5, Math.min(1.5, newScale));
 
-    let origin = singleScaleOriginRef.current;
-
-    if (!origin) {
-      const rawBase =
-        previewMap ||
-        appliedMapRef.current["single"] ||
-        committedMapRef.current ||
-        Object.fromEntries(
-          filteredStars.map((s) => [s.id, { x: s.x, y: s.y }])
-        );
-
-      origin = ensureMinSize(rawBase, 0.12);
-      singleScaleOriginRef.current = origin;
+    let base = singleScaleOriginRef.current;
+    if (!base) {
+      const rawBase = Object.fromEntries(
+        filteredStars.map((s) => [s.id, { x: s.x, y: s.y }])
+      );
+      base = ensureMinSize(rawBase, 0.12);
+      singleScaleOriginRef.current = base;
     }
 
-    const pts = Object.values(origin);
-    const bbox = computeBBoxFromPoints(pts);
-    if (!bbox) return;
-    const { cx, cy } = bbox;
+    const baseBox = computeBBoxFromPoints(Object.values(base));
+    if (!baseBox) return;
+
+    const currentApplied = appliedMapRef.current["single"] || base;
+    const currentForCenter = previewMap || currentApplied;
+    const committedBox = computeBBoxFromPoints(Object.values(currentForCenter));
+
+    const tx = committedBox && baseBox ? committedBox.cx - baseBox.cx : 0;
+    const ty = committedBox && baseBox ? committedBox.cy - baseBox.cy : 0;
 
     const scaled = {};
-    Object.entries(origin).forEach(([id, p]) => {
-      const dx = p.x - cx;
-      const dy = p.y - cy;
+    Object.entries(base).forEach(([id, p]) => {
+      const dx = p.x - baseBox.cx;
+      const dy = p.y - baseBox.cy;
       scaled[id] = {
-        x: cx + dx * sAbs,
-        y: cy + dy * sAbs,
+        x: baseBox.cx + dx * sAbs + tx,
+        y: baseBox.cy + dy * sAbs + ty,
       };
     });
 
     const fitted = fitMapIntoView(scaled, 0);
+
+    if (!pendingApply) {
+      const original = appliedMapRef.current["single"] || currentForCenter;
+      originalPositionRef.current = deepClone(original);
+    }
 
     setPreviewMap(fitted);
     onTransform?.(fitted);
     setPendingApply(true);
 
     if (commit) {
-      committedMapRef.current = fitted;
-      appliedMapRef.current["single"] = fitted;
+      appliedMapRef.current["single"] = deepClone(fitted);
       scaleRef.current = sAbs;
-      singleScaleOriginRef.current = deepClone(fitted);
+      setScaleUI(sAbs);
       onTransformEnd?.(fitted);
       setPendingApply(false);
       setAppliedVersion((v) => v + 1);
@@ -655,6 +796,7 @@ export default function StarSkyDate({
   const activeConstBBox = (() => {
     if (!multipleMode || !activeConst) return null;
     const applied = appliedMapRef.current[activeConst.id];
+    const base = baseConstShapesRef.current[activeConst.id];
     const pts = (activeConst.stars || []).map((s) => {
       const id = s.id ?? s.starId;
       if (
@@ -664,6 +806,7 @@ export default function StarSkyDate({
       )
         return previewMap[id];
       if (applied && applied[id]) return applied[id];
+      if (base && base[id]) return base[id];
       return { x: s.x, y: s.y };
     });
     return computeBBoxFromPoints(pts);
@@ -778,6 +921,7 @@ export default function StarSkyDate({
           {multipleMode &&
             filteredConstellationGroups.map((g) => {
               const appliedForThis = appliedMapRef.current[g.id] || null;
+              const baseMap = baseConstShapesRef.current[g.id] || null;
               return (g.connections || []).map((conn, idx) => {
                 const [a, b] = Array.isArray(conn)
                   ? conn
@@ -796,14 +940,16 @@ export default function StarSkyDate({
                 const p1 = (previewMap &&
                   g.id === activeConstellationId &&
                   previewMap[paId]) ||
-                  (appliedForThis && appliedForThis[paId]) || {
+                  (appliedForThis && appliedForThis[paId]) ||
+                  (baseMap && baseMap[paId]) || {
                     x: pa.x,
                     y: pa.y,
                   };
                 const p2 = (previewMap &&
                   g.id === activeConstellationId &&
                   previewMap[pbId]) ||
-                  (appliedForThis && appliedForThis[pbId]) || {
+                  (appliedForThis && appliedForThis[pbId]) ||
+                  (baseMap && baseMap[pbId]) || {
                     x: pb.x,
                     y: pb.y,
                   };
@@ -957,6 +1103,7 @@ export default function StarSkyDate({
         {multipleMode &&
           filteredConstellationGroups.map((g) => {
             const appliedForThis = appliedMapRef.current[g.id] || null;
+            const baseMap = baseConstShapesRef.current[g.id] || null;
             return (g.stars || []).map((s) => {
               const img = colorImageMap[(s.color || "").toUpperCase()];
               if (!img) return null;
@@ -965,7 +1112,8 @@ export default function StarSkyDate({
               const p = (previewMap &&
                 g.id === activeConstellationId &&
                 previewMap[id]) ||
-                (appliedForThis && appliedForThis[id]) || { x: s.x, y: s.y };
+                (appliedForThis && appliedForThis[id]) ||
+                (baseMap && baseMap[id]) || { x: s.x, y: s.y };
 
               const showPulse =
                 locked &&
@@ -1060,27 +1208,29 @@ export default function StarSkyDate({
             }}
           >
             <div>{activeConst.name || "(미지정 별자리)"}</div>
-            <div className="opacity-80">
-              {constellationCreatedAtRef.current[activeConst.id] ||
-                getTodayLocal()}
-            </div>
+            {constellationCreatedAtRef.current[activeConst.id] && (
+              <div className="opacity-80">
+                {constellationCreatedAtRef.current[activeConst.id]}
+              </div>
+            )}
           </div>
         )}
       </div>
 
+      {/* 단일 별자리 스케일 조절 패널 */}
       {!multipleMode && locked && isSelected && (
         <div
           className="absolute right-4 top-1/2 -translate-y-1/2 z-20 bg-black/35 backdrop-blur px-4 py-3 rounded-xl flex flex-col gap-3 min-w-[220px]"
           onPointerDown={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between">
-            <div className="text-white/85 text-sm">크기 조절 (0.2x ~ 1.0x)</div>
+            <div className="text-white/85 text-sm">크기 조절 (0.5x ~ 2.0x)</div>
             <div className="text-white/70 text-xs">x{scaleUI.toFixed(2)}</div>
           </div>
           <input
             type="range"
-            min={0.2}
-            max={1.0}
+            min={0.5}
+            max={2.0}
             step={0.02}
             value={scaleUI}
             onChange={(e) => {
@@ -1090,34 +1240,33 @@ export default function StarSkyDate({
             }}
           />
           <div className="flex items-center justify-between text-white/70 text-xs">
-            <span>0.2x</span>
             <span>0.5x</span>
             <span>1.0x</span>
+            <span>2.0x</span>
           </div>
           <button
             className="px-3 py-1.5 rounded bg-white/75 hover:bg-white text-black text-sm"
             onClick={() => {
               if (!previewMap) {
-                if (originalPositionRef.current) {
-                  setPreviewMap(null);
-                  onTransformEnd?.(originalPositionRef.current);
-                  singleScaleOriginRef.current = originalPositionRef.current;
-                }
                 setPendingApply(false);
                 return;
               }
               const ok = window.confirm("이 위치로 적용하시겠습니까?");
               if (!ok) {
                 if (originalPositionRef.current) {
+                  appliedMapRef.current["single"] = deepClone(
+                    originalPositionRef.current
+                  );
                   setPreviewMap(null);
                   onTransformEnd?.(originalPositionRef.current);
-                  singleScaleOriginRef.current = originalPositionRef.current;
+                  setAppliedVersion((v) => v + 1);
                 }
                 setPendingApply(false);
                 return;
               }
               applyScalePreviewSingle(scaleUI, { commit: true });
-              onApply?.(previewMap);
+              const applied = appliedMapRef.current["single"] || previewMap;
+              onApply?.(applied);
               setPreviewMap(null);
               setPendingApply(false);
               setIsSelected(true);
@@ -1128,6 +1277,7 @@ export default function StarSkyDate({
         </div>
       )}
 
+      {/* 여러 별자리 스케일 조절 패널 */}
       {multipleMode && locked && activeConstellationId && isSelected && (
         <div
           className="absolute right-4 top-1/2 -translate-y-1/2 z-20 bg-black/35 backdrop-blur px-4 py-3 rounded-xl flex flex-col gap-3 min-w-[220px]"
@@ -1146,8 +1296,8 @@ export default function StarSkyDate({
           </div>
           <input
             type="range"
-            min={0.2}
-            max={1.0}
+            min={0.5}
+            max={2.0}
             step={0.05}
             value={
               scaleUIMap[activeConstellationId] ??
@@ -1155,7 +1305,9 @@ export default function StarSkyDate({
               1
             }
             onChange={(e) => {
-              const v = parseFloat(e.target.value);
+              const vRaw = parseFloat(e.target.value);
+              const v = Math.max(0.5, Math.min(2.0, vRaw));
+
               setScaleUIMap((prev) => ({
                 ...prev,
                 [activeConstellationId]: v,
@@ -1200,8 +1352,8 @@ export default function StarSkyDate({
             }}
           />
           <div className="flex items-center justify-between text-white/70 text-xs">
-            <span>0.2x</span>
-            <span>1.0x</span>
+            <span>0.5x</span>
+            <span>2.0x</span>
           </div>
           <button
             className="px-3 py-1.5 rounded bg-white/75 hover:bg-white text-black text-sm"

--- a/src/components/StarSkyDate.jsx
+++ b/src/components/StarSkyDate.jsx
@@ -23,20 +23,15 @@ const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 const EDGE_PAD = 0.02;
 const LABEL_TOP_FLIP_Y = 0.1;
 
-// 별이 UI 버튼/아이콘 영역 안으로 못 들어가게 하기 위한 헬퍼
 function avoidUiZones(nx, ny, rect) {
   if (!rect) return { x: nx, y: ny };
   let px = nx * rect.width;
   let py = ny * rect.height;
 
   const zones = [
-    // 좌측 상단 햄버거 메뉴 – 살짝 더 작은 영역
     { x1: 0, y1: 0, x2: 60, y2: 65 },
-
-    // 우측 상단 GENERATE 버튼 – 좌우/세로 조금 줄이기
     { x1: rect.width - 115, y1: 0, x2: rect.width, y2: 50 },
 
-    // 하단 월 이동 바 – 좌우/위쪽 약간 줄이기
     {
       x1: rect.width / 2 - 160,
       y1: rect.height - 80,
@@ -45,11 +40,10 @@ function avoidUiZones(nx, ny, rect) {
     },
   ];
 
-  const margin = 4; // 바깥으로 살짝 밀어낼 여유
+  const margin = 4;
 
   zones.forEach((z) => {
     if (px >= z.x1 && px <= z.x2 && py >= z.y1 && py <= z.y2) {
-      // 네 변까지의 거리 계산
       const dLeft = px - z.x1;
       const dRight = z.x2 - px;
       const dTop = py - z.y1;
@@ -58,16 +52,12 @@ function avoidUiZones(nx, ny, rect) {
       const minD = Math.min(dLeft, dRight, dTop, dBottom);
 
       if (minD === dLeft) {
-        // 왼쪽 벽이 제일 가까우면 왼쪽으로 밀기
         px = z.x1 - margin;
       } else if (minD === dRight) {
-        // 오른쪽 벽이 제일 가까우면 오른쪽으로 밀기
         px = z.x2 + margin;
       } else if (minD === dTop) {
-        // 위쪽이 제일 가까우면 위로 밀기
         py = z.y1 - margin;
       } else {
-        // 아래쪽이 제일 가까우면 아래로 밀기
         py = z.y2 + margin;
       }
     }
@@ -226,7 +216,6 @@ export default function StarSkyDate({
 
   const constellationCreatedAtRef = useRef({});
 
-  // 라벨 날짜: 모달에서 생성 완료한 날짜만 사용, 없으면 새로 오늘로 채우지 않음
   useEffect(() => {
     if (!filteredConstellationGroups.length) return;
     const store = constellationCreatedAtRef.current;
@@ -247,7 +236,6 @@ export default function StarSkyDate({
       if (modalPickedDate) {
         store[id] = String(modalPickedDate).slice(0, 10);
       }
-      // modalPickedDate가 없으면 아무것도 하지 않음 (기존 값 유지, 없으면 undefined)
     });
   }, [filteredConstellationGroups]);
 
@@ -298,11 +286,9 @@ export default function StarSkyDate({
     prevMultipleRef.current = multipleMode;
   }, [multipleMode]);
 
-  // 여러 별자리 기본 크기 통일을 위한 기준 크기 / 정규화 여부
-  const multiBaseSizeRef = useRef(null); // 기준 별자리(최고자리)의 크기
-  const multiNormalizedRef = useRef({}); // id -> boolean
+  const multiBaseSizeRef = useRef(null);
+  const multiNormalizedRef = useRef({});
 
-  // 여러 별자리(그룹) 기본 크기 통일 + 초기 위치 세팅
   useEffect(() => {
     if (!multipleMode) return;
 
@@ -314,7 +300,6 @@ export default function StarSkyDate({
       const id = g.id;
       if (!id) return;
 
-      // 1) id별 base shape 없으면 한 번 만들기
       if (!baseStore[id]) {
         const base = {};
         (g.stars || []).forEach((s) => {
@@ -330,7 +315,6 @@ export default function StarSkyDate({
       const box = computeBBoxFromPoints(Object.values(base));
       if (!box) return;
 
-      // 2) 기준 크기(targetSize) 없으면 첫 번째 별자리 크기로 설정
       if (multiBaseSizeRef.current == null) {
         multiBaseSizeRef.current = Math.max(box.w, box.h);
       }
@@ -339,7 +323,6 @@ export default function StarSkyDate({
       const curSize = Math.max(box.w, box.h) || 0.0001;
       const factor = targetSize / curSize;
 
-      // 3) 아직 이 id는 기준 크기로 정규화 안 했으면, 기준 크기에 맞게 스케일
       if (!normalized[id]) {
         let scaled = base;
         if (Math.abs(factor - 1) > 1e-3) {
@@ -370,7 +353,6 @@ export default function StarSkyDate({
     }
   }, [multipleMode, filteredConstellationGroups]);
 
-  // 현재 별의 실제 위치 얻기 (단일 별자리용)
   const positionOf = (s) => {
     if (previewMap && previewMap[s.id]) {
       return previewMap[s.id];
@@ -391,7 +373,6 @@ export default function StarSkyDate({
     [livePoints]
   );
 
-  // locked 되었을 때, 단일 별자리 기본 스케일 적용 (항상 x1.0)
   useEffect(() => {
     if (multipleMode) {
       didInitialScaleRef.current = false;
@@ -408,7 +389,7 @@ export default function StarSkyDate({
       const base = ensureMinSize(baseRaw, 0.12);
 
       singleScaleOriginRef.current = base;
-      const clampedInit = 1.0; // 항상 x1.0을 기본으로
+      const clampedInit = 1.0;
       scaleRef.current = clampedInit;
       setScaleUI(clampedInit);
 
@@ -470,7 +451,6 @@ export default function StarSkyDate({
     };
   };
 
-  // 멀티 모드에서 "현재 화면에 보이는" 별자리 맵을 얻기 위한 헬퍼
   const getConstellationMapForDrag = (constellation) => {
     const constId = constellation.id;
     const appliedForThis = appliedMapRef.current[constId];
@@ -498,7 +478,6 @@ export default function StarSkyDate({
     return map;
   };
 
-  // 단일 별자리 드래그 시작
   const startMoveDragSingle = (e) => {
     if (!locked || !liveBBox) return;
     e.preventDefault();
@@ -671,7 +650,6 @@ export default function StarSkyDate({
     let nx = clampToView(starDrag.originPos.x + dxPx / r.width);
     let ny = clampToView(starDrag.originPos.y + dyPx / r.height);
 
-    // UI 버튼/아이콘 영역 안으로 못 들어가게 조정
     const adjusted = avoidUiZones(nx, ny, r);
     nx = adjusted.x;
     ny = adjusted.y;
@@ -726,7 +704,6 @@ export default function StarSkyDate({
     setStarDrag(null);
   };
 
-  // 단일 별자리 크기 조절 (현재 상태 기준으로 스케일링)
   const applyScalePreviewSingle = (newScale, { commit = false } = {}) => {
     const sAbs = Math.max(0.5, Math.min(1.5, newScale));
 
@@ -1217,7 +1194,6 @@ export default function StarSkyDate({
         )}
       </div>
 
-      {/* 단일 별자리 스케일 조절 패널 */}
       {!multipleMode && locked && isSelected && (
         <div
           className="absolute right-4 top-1/2 -translate-y-1/2 z-20 bg-black/35 backdrop-blur px-4 py-3 rounded-xl flex flex-col gap-3 min-w-[220px]"
@@ -1277,7 +1253,6 @@ export default function StarSkyDate({
         </div>
       )}
 
-      {/* 여러 별자리 스케일 조절 패널 */}
       {multipleMode && locked && activeConstellationId && isSelected && (
         <div
           className="absolute right-4 top-1/2 -translate-y-1/2 z-20 bg-black/35 backdrop-blur px-4 py-3 rounded-xl flex flex-col gap-3 min-w-[220px]"

--- a/src/pages/StarSky.jsx
+++ b/src/pages/StarSky.jsx
@@ -113,12 +113,6 @@ const StarSky = () => {
     if (!Array.isArray(rawList)) return [];
 
     return rawList.map((c) => {
-      const baseDate =
-        c.createdAt ||
-        c.createdDate ||
-        c.date ||
-        (c.stars?.[0]?.date ?? new Date().toISOString().slice(0, 10));
-
       const rawStars =
         c.stars || c.starts || c.starList || c.star || c.starEntities || [];
 
@@ -139,12 +133,20 @@ const StarSky = () => {
           ? c.description
           : cached?.desc || "";
 
+      const baseDate =
+        cached?.createdAt ||
+        c.createdAt ||
+        c.createdDate ||
+        c.date ||
+        (rawStars[0]?.date ?? new Date().toISOString().slice(0, 10));
+
       return {
         id: c.constellationId ?? c.id,
         constellationId: c.constellationId ?? c.id,
         name: finalName,
         description: finalDesc,
         createdAt: baseDate,
+        constellationCreatedAt: baseDate,
         x: typeof c.x === "number" ? clamp01(c.x) : 0.5,
         y: typeof c.y === "number" ? clamp01(c.y) : 0.5,
         stars: rawStars.map((s) => ({
@@ -361,6 +363,7 @@ const StarSky = () => {
         [key]: {
           name: trimmedName || "미지정 별자리",
           desc: trimmedDesc || "",
+          createdAt: createdAtStr,
         },
       };
       saveNameCache(nameCacheRef.current);


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
### 1. 별자리 생성 모달 UI 수정
<img width="1512" height="823" alt="스크린샷 2025-11-06 오후 9 17 19" src="https://github.com/user-attachments/assets/4784c801-b0fc-45ee-8d6a-db36c945f049" />
-> 이 모달에서는 별자리 선을 이을 수 있도록 구현했습니다. 
<br />
-> 기존에 별이 자동으로 선택되어서 다음 선을 이을 때 바로 이어지던 것을 선을 잇고 난 후에 선택이 초기화 되서 두 별을 선택해야지 다음 선을 이을 수 있도록 수정했습니다.
<img width="1506" height="818" alt="스크린샷 2025-11-06 오후 9 17 47" src="https://github.com/user-attachments/assets/7e55ae61-ad96-48be-aa21-84ab904d62a8" />
-> 선을 생성하면 아래의 선을 지울 수 있는 버튼이 활성화 됩니다.
<img width="1510" height="821" alt="스크린샷 2025-11-06 오후 9 18 07" src="https://github.com/user-attachments/assets/80de1d69-e554-4a69-840c-eaa1dcf34ef8" />
-> 이 모달에서는 이름과 설명을 적을 수 있도록 구현했습니다.
<br />
-> 이 모달에서는 선을 잇거나 별을 움직일 수 없습니다. 하지만 <- 버튼을 누르면 뒤로 다시 돌아가서 선을 다시 잇거나 별을 움직일 수 있습니다.
<img width="952" height="714" alt="스크린샷 2025-11-06 오후 9 18 53" src="https://github.com/user-attachments/assets/b4e9f315-333f-40a3-b4f2-2c79d82927ab" />
-> 이름과 설명을 적어야만 완료 버튼이 활성화 되도록 했습니다.

### 2. 모달에서 별자리 생성 후 모든 별자리들이 정해진 별자리 크기로 나타나도록 구현
<img width="1512" height="822" alt="스크린샷 2025-11-06 오후 9 19 03" src="https://github.com/user-attachments/assets/8eede067-f35f-419e-9e00-a14a025074e5" />
-> 별자리 생성 후 밤하늘 페이지에 나타나는 별자리의 크기를 다 동일할 수 있도록 구현했습니다.

### 3. 별 이동 제한
<img width="98" height="99" alt="스크린샷 2025-11-06 오후 9 20 08" src="https://github.com/user-attachments/assets/7fb18f89-1781-4469-8bb5-47741e51908b" />
<img width="121" height="62" alt="스크린샷 2025-11-06 오후 9 20 16" src="https://github.com/user-attachments/assets/0eab4ac4-80f7-4a66-aba4-8f79182d274d" />
<img width="352" height="95" alt="스크린샷 2025-11-06 오후 9 20 25" src="https://github.com/user-attachments/assets/135c17b5-1ed1-44e8-9d2b-4eea8b24a85d" />

-> 별이 사이드바 아이콘, 생성 버튼, 달 이동 버튼에 생성되지도 못하고 이동하지도 못하도록 구현했습니다.

### 4. 별자리 크기 조절 탭 수정
<img width="268" height="199" alt="스크린샷 2025-11-06 오후 9 19 22" src="https://github.com/user-attachments/assets/d577e5a1-64f8-4c55-98e3-9357eeb7525d" />

-> 별자리 생성 후 정해진 별자리 크기로 밤하늘 페이지에 나타나도록 구현하여서 별자리 크기 조절을 x0.5 ~ x2.0까지 할 수 있도록 수정했습니다. 원상태의 별자리는 x1.0 입니다.

### 5. 호버 시 라벨에 나타나는 날짜 수정
<img width="286" height="265" alt="스크린샷 2025-11-06 오후 9 35 16" src="https://github.com/user-attachments/assets/f0b3db6f-5c29-472d-8073-ba3e21e17ba7" />

-> 호버 시 라벨에 나타나는 날짜가 별자리 생성 날짜로 나타나도록 수정했습니다. (백엔드에서 API로 받는게 아니라 프론트에서 직접 생성일자가 나타나도록 하여서 오늘 생성한 별자리부터 적용됩니다! 이전에꺼는 적용안됨)






### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
