### PR TITLE
Feature/archivedetail : 별자리아카이브 상세페이지 구현

### DIFF
--- a/src/components/ArchiveCard/ConstellationDetailModal.jsx
+++ b/src/components/ArchiveCard/ConstellationDetailModal.jsx
@@ -40,11 +40,11 @@ const colorIconMap = {
 };
 
 const EMOTIONS = [
-  { key: "HAPPY",    label: "행복해요" },
-  { key: "SAD",      label: "슬퍼요" },
-  { key: "ANGRY",    label: "화나요" },
-  { key: "FUNNY",    label: "웃겨요" },
-  { key: "WOW",      label: "놀라워요" },
+  { key: "HAPPY", label: "행복해요" },
+  { key: "SAD", label: "슬퍼요" },
+  { key: "ANGRY", label: "화나요" },
+  { key: "FUNNY", label: "웃겨요" },
+  { key: "WOW", label: "놀라워요" },
   { key: "CONFUSED", label: "잘 모르겠어요" },
 ];
 
@@ -56,6 +56,7 @@ function pick(obj, keys, def = 0) {
 function formatKDate(iso) {
   if (!iso) return "-";
   const d = new Date(iso);
+  if (isNaN(d)) return "-";
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -65,7 +66,7 @@ function formatKDate(iso) {
 function toISODate(input) {
   if (!input) return null;
   const d = typeof input === "string" ? new Date(input) : input;
-  if (isNaN(d.getTime())) return null;
+  if (isNaN(d?.getTime?.())) return null;
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -74,7 +75,7 @@ function toISODate(input) {
 
 function emotionLabel(e) {
   const found = EMOTIONS.find((v) => v.key === e);
-  return found ? found.label : (e || "-");
+  return found ? found.label : e || "-";
 }
 
 export default function ConstellationDetailModal({
@@ -82,27 +83,25 @@ export default function ConstellationDetailModal({
   onClose,
   detail,
   initial,
+  items = [],
+  index = 0,
+  onChangeIndex,
+  loop = true,
 }) {
-  // 훅 호출 전 조기 반환 (Hook 순서 안전)
   if (!open) return null;
 
   const navigate = useNavigate();
 
-  const model = detail || initial || {};
-  const {
-    name,
-    description,
-    date,
-    stars = [],
-    connections = [],
-  } = model;
+  const hasList = Array.isArray(items) && items.length > 0;
+  const model = hasList && items?.[index] ? items[index] : (detail || initial || {});
+  const { name, description, date, stars = [], connections = [] } = model || {};
 
   function resolveEmotionFromStar(s) {
-    const explicit = s.emotion || s.emotionType || s.mood;
+    const explicit = s?.emotion || s?.emotionType || s?.mood;
     if (explicit) return explicit;
-    const colorKey = (s.color || "").toUpperCase();
+    const colorKey = String(s?.color || "").toUpperCase();
     return COLOR_TO_EMOTION[colorKey] || null;
-    }
+  }
 
   const counts = useMemo(() => {
     const fromFields = Object.fromEntries(
@@ -133,11 +132,55 @@ export default function ConstellationDetailModal({
     onClose?.();
   };
 
+  const total = hasList ? items.length : 1;
+  const canNav = total > 1;
+
+  const goIdx = (next) => {
+    if (!canNav || !onChangeIndex) return;
+    const n = loop ? (next + total) % total : Math.min(Math.max(next, 0), total - 1);
+    onChangeIndex(n);
+  };
+  const goPrev = () => goIdx(index - 1);
+  const goNext = () => goIdx(index + 1);
+
+  React.useEffect(() => {
+    const onKey = (e) => {
+      if (!open) return;
+      if (e.key === "ArrowLeft") { e.preventDefault(); goPrev(); }
+      if (e.key === "ArrowRight") { e.preventDefault(); goNext(); }
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, index, total]);
+
   return (
     <div className="fixed inset-0 z-[100]">
       <div className="absolute inset-0 bg-black/60" onClick={onClose} aria-hidden="true" />
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                      bg-white/85  text-neutral-900 w-280 max-w-[95vw] rounded-2xl shadow-2xl">
+      <div className="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+                      bg-white/85 text-neutral-900 w-280 max-w-[95vw] rounded-2xl shadow-2xl relative">
+        {canNav && ( // 방향키 버튼으로 별자리 상세페이지 이동
+          <>
+            <button
+              aria-label="이전 별자리"
+              onClick={(e) => { e.stopPropagation(); goPrev(); }}
+              className="absolute left-[-80px] top-1/2 -translate-y-1/2
+                         flex items-center justify-center select-none"
+            >
+              <span className="text-white text-8xl leading-none  hover:text-gray-300">‹</span>
+            </button>
+            <button
+              aria-label="다음 별자리"
+              onClick={(e) => { e.stopPropagation(); goNext(); }}
+              className="absolute right-[-80px] top-1/2 -translate-y-1/2
+                          flex items-center justify-center select-none"
+            >
+              <span className="text-white text-8xl leading-none hover:text-gray-300">›</span>
+            </button>
+          </>
+        )}
+
         <div className="flex gap-6 px-8 pt-8">
           <div
             className="rounded-2xl overflow-hidden mt-5"
@@ -161,9 +204,8 @@ export default function ConstellationDetailModal({
           <div className="flex flex-col flex-1">
             <div className="flex items-start justify-between">
               <div>
-                {/* 상단 표시 날짜는 클릭 불가로 유지 */}
                 <div className="text-neutral-500 mt-5">{formatKDate(date)}</div>
-                <div className="text-3xl font-bold mt-1">{name}</div>
+                <div className="text-3xl font-bold mt-1">{name || ""}</div>
               </div>
               <button
                 onClick={onClose}
@@ -188,12 +230,7 @@ export default function ConstellationDetailModal({
                     <span className="w-32 text-xl">{em.label}</span>
                     <div className="flex items-center">
                       {Array.from({ length: Math.min(6, cnt) }).map((_, idx) => (
-                        <img
-                          key={idx}
-                          src={iconSrc}
-                          alt={`${em.label} (${colorKey})`}
-                          className="w-8 h-8"
-                        />
+                        <img key={idx} src={iconSrc} alt={`${em.label} (${colorKey})`} className="w-8 h-8" />
                       ))}
                     </div>
                   </div>
@@ -215,32 +252,29 @@ export default function ConstellationDetailModal({
               <div>생성 날짜</div>
             </div>
 
-            <div className="max-h-50 overflow-y-auto divide-y divide-[#D9D9D9]">
+            <div className="max-h-50 overflow-y-au>to divide-y divide-[#D9D9D9]">
               {(stars || []).map((s) => {
-                const colorKey = (s.color || "").toUpperCase();
+                const colorKey = String(s?.color || "").toUpperCase();
                 const icon = colorIconMap[colorKey] || yellowColorIcon;
                 const e = resolveEmotionFromStar(s);
+                const key = s?.starId || s?.id;
 
                 return (
-                  <div
-                    key={s.starId}
-                    className="grid grid-cols-3 items-center px-6 py-3 bg-[#EBEBEB]"
-                  >
+                  <div key={key} className="grid grid-cols-3 items-center px-6 py-3 bg-[#EBEBEB]">
                     <img src={icon} alt={colorKey || "COLOR"} className="w-8 h-8 ml-4" />
                     <div className="px-2">{emotionLabel(e)}</div>
 
-                    {/* 날짜 셀: 스타일 변경 없이 클릭 이동 */}
                     <div
-                    className="cursor-pointer hover:underline"
+                      className="cursor-pointer hover:underline"
                       role="button"
                       tabIndex={0}
                       aria-label="해당 날짜 일기장으로 이동"
-                      onClick={() => goCalendarWith(s.date)}
+                      onClick={() => goCalendarWith(s?.date)}
                       onKeyDown={(ev) => {
-                        if (ev.key === "Enter" || ev.key === " ") goCalendarWith(s.date);
+                        if (ev.key === "Enter" || ev.key === " ") goCalendarWith(s?.date);
                       }}
                     >
-                      {formatKDate(s.date)}
+                      {formatKDate(s?.date)}
                     </div>
                   </div>
                 );

--- a/src/components/ArchiveCard/ConstellationDetailModal.jsx
+++ b/src/components/ArchiveCard/ConstellationDetailModal.jsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from "react";
 import { IoClose } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
 import ConstellationMini from "../ConstellationMini";
 import bgImage from "../../assets/background.png";
-import { FaPencil } from "react-icons/fa6";
-
 
 import yellowColorIcon from "../../assets/emotions/yellow.png";
 import blueColorIcon from "../../assets/emotions/blue.png";
@@ -21,7 +20,6 @@ const COLOR_TO_EMOTION = {
   PURPLE: "CONFUSED",
 };
 
-
 const EMOTION_TO_COLOR = {
   HAPPY: "YELLOW",
   SAD: "BLUE",
@@ -32,7 +30,6 @@ const EMOTION_TO_COLOR = {
   CRYING: "BLUE",
 };
 
-
 const colorIconMap = {
   YELLOW: yellowColorIcon,
   BLUE: blueColorIcon,
@@ -42,21 +39,17 @@ const colorIconMap = {
   PURPLE: purpleColorIcon,
 };
 
-
 const EMOTIONS = [
   { key: "HAPPY",    label: "행복해요" },
   { key: "SAD",      label: "슬퍼요" },
   { key: "ANGRY",    label: "화나요" },
   { key: "FUNNY",    label: "웃겨요" },
   { key: "WOW",      label: "놀라워요" },
-  { key: "CONFUSED", label: "혼란스러워요" },
-  
+  { key: "CONFUSED", label: "잘 모르겠어요" },
 ];
 
 function pick(obj, keys, def = 0) {
-  for (const k of keys) {
-    if (obj && obj[k] != null) return obj[k];
-  }
+  for (const k of keys) if (obj && obj[k] != null) return obj[k];
   return def;
 }
 
@@ -69,8 +62,18 @@ function formatKDate(iso) {
   return `${y}년 ${m}월 ${day}일`;
 }
 
+function toISODate(input) {
+  if (!input) return null;
+  const d = typeof input === "string" ? new Date(input) : input;
+  if (isNaN(d.getTime())) return null;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 function emotionLabel(e) {
-  const found = EMOTIONS.find(v => v.key === e);
+  const found = EMOTIONS.find((v) => v.key === e);
   return found ? found.label : (e || "-");
 }
 
@@ -80,7 +83,10 @@ export default function ConstellationDetailModal({
   detail,
   initial,
 }) {
+  // 훅 호출 전 조기 반환 (Hook 순서 안전)
   if (!open) return null;
+
+  const navigate = useNavigate();
 
   const model = detail || initial || {};
   const {
@@ -91,24 +97,25 @@ export default function ConstellationDetailModal({
     connections = [],
   } = model;
 
-  /* 별에서 감정 추론: 명시적 필드 우선, 없으면 색상->감정 매핑 사용 */
   function resolveEmotionFromStar(s) {
     const explicit = s.emotion || s.emotionType || s.mood;
     if (explicit) return explicit;
     const colorKey = (s.color || "").toUpperCase();
     return COLOR_TO_EMOTION[colorKey] || null;
-  }
-
+    }
 
   const counts = useMemo(() => {
     const fromFields = Object.fromEntries(
-      EMOTIONS.map(e => [e.key, pick(model, [`${e.key.toLowerCase()}Count`, `${e.key}Count`], null)])
+      EMOTIONS.map((e) => [
+        e.key,
+        pick(model, [`${e.key.toLowerCase()}Count`, `${e.key}Count`], null),
+      ])
     );
 
-    const needCalc = Object.values(fromFields).some(v => v == null);
+    const needCalc = Object.values(fromFields).some((v) => v == null);
     if (!needCalc) return fromFields;
 
-    const agg = Object.fromEntries(EMOTIONS.map(e => [e.key, 0]));
+    const agg = Object.fromEntries(EMOTIONS.map((e) => [e.key, 0]));
     (stars || []).forEach((s) => {
       const e = resolveEmotionFromStar(s);
       if (e && agg[e] != null) agg[e] += 1;
@@ -119,23 +126,24 @@ export default function ConstellationDetailModal({
     }, {});
   }, [model, stars]);
 
+  const goCalendarWith = (anyDate) => {
+    const iso = toISODate(anyDate);
+    if (!iso) return;
+    navigate(`/calendar?date=${iso}`);
+    onClose?.();
+  };
+
   return (
     <div className="fixed inset-0 z-[100]">
-      <div
-        className="absolute inset-0 bg-black/60"
-        onClick={onClose}
-        aria-hidden="true"
-      />
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} aria-hidden="true" />
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
-                      bg-white text-neutral-900 w-[960px] max-w-[95vw] rounded-2xl shadow-2xl">
-        {/* 헤더 */}
-        <div className="flex gap-6 p-8">
-          {/* 별 썸네일 */}
+                      bg-white/85  text-neutral-900 w-280 max-w-[95vw] rounded-2xl shadow-2xl">
+        <div className="flex gap-6 px-8 pt-8">
           <div
             className="rounded-2xl overflow-hidden mt-5"
             style={{
-              width: 280,
-              height: 280,
+              width: 330,
+              height: 330,
               backgroundImage: `url(${bgImage})`,
               backgroundSize: "cover",
               backgroundPosition: "center",
@@ -144,16 +152,17 @@ export default function ConstellationDetailModal({
             <ConstellationMini
               stars={stars}
               connections={connections}
-              width={280}
-              height={280}
+              width={300}
+              height={300}
               hideBackground={true}
             />
           </div>
 
-          <div className="flex flex-col flex-1 gap-3">
+          <div className="flex flex-col flex-1">
             <div className="flex items-start justify-between">
               <div>
-                <div className="text-neutral-500 text-sm mt-5">{formatKDate(date)}</div>
+                {/* 상단 표시 날짜는 클릭 불가로 유지 */}
+                <div className="text-neutral-500 mt-5">{formatKDate(date)}</div>
                 <div className="text-3xl font-bold mt-1">{name}</div>
               </div>
               <button
@@ -165,18 +174,17 @@ export default function ConstellationDetailModal({
               </button>
             </div>
 
-            <div className="text-neutral-500 leading-relaxed">
+            <div className="text-neutral-500 text-xl leading-relaxed">
               {description || "설명이 없습니다."}
             </div>
 
-      
-            <div className="mt-4 grid grid-rows-2 gap-y-2">
+            <div className="mt-4 grid grid-rows-2 gap-y-1 font-pretendard">
               {EMOTIONS.map((em) => {
                 const colorKey = EMOTION_TO_COLOR[em.key] || "YELLOW";
                 const iconSrc = colorIconMap[colorKey];
                 const cnt = counts[em.key] || 0;
                 return (
-                  <div key={em.key} className="flex items-center gap-3">
+                  <div key={em.key} className="flex items-center gap-3 ">
                     <span className="w-32 text-xl">{em.label}</span>
                     <div className="flex items-center">
                       {Array.from({ length: Math.min(6, cnt) }).map((_, idx) => (
@@ -196,32 +204,48 @@ export default function ConstellationDetailModal({
         </div>
 
         <div className=" bg-neutral-50" />
-    
 
-     
-        <div className="p-6">
+        <div className="p-6 font-pretendard">
           <div className="font-semibold mb-3 text-[#4F4F4F]/80 text-xl">내가 남긴 기록 보기</div>
 
-          <div className="border border-[#F4F4F4] rounded-xl overflow-hidden">
-            <div className="grid grid-cols-3 bg-[#DFDFDF] px-12 py-3">
+          <div className="border border-[#d4d4d4] rounded-xl overflow-hidden">
+            <div className="grid grid-cols-3 bg-[#d4d4d4] px-12 py-3 font-semibold">
               <div>별</div>
               <div>감정</div>
               <div>생성 날짜</div>
             </div>
 
-            <div className="max-h-80 overflow-y-auto divide-y divide-[#D9D9D9]">
+            <div className="max-h-50 overflow-y-auto divide-y divide-[#D9D9D9]">
               {(stars || []).map((s) => {
                 const colorKey = (s.color || "").toUpperCase();
                 const icon = colorIconMap[colorKey] || yellowColorIcon;
                 const e = resolveEmotionFromStar(s);
+
                 return (
-                  <div key={s.starId} className="grid grid-cols-3 items-center px-6 py-3 bg-[#EBEBEB]/50">
+                  <div
+                    key={s.starId}
+                    className="grid grid-cols-3 items-center px-6 py-3 bg-[#EBEBEB]"
+                  >
                     <img src={icon} alt={colorKey || "COLOR"} className="w-8 h-8 ml-4" />
-                    <div>{emotionLabel(e)}</div>
-                    <div>{formatKDate(s.date)}</div>
+                    <div className="px-2">{emotionLabel(e)}</div>
+
+                    {/* 날짜 셀: 스타일 변경 없이 클릭 이동 */}
+                    <div
+                    className="cursor-pointer hover:underline"
+                      role="button"
+                      tabIndex={0}
+                      aria-label="해당 날짜 일기장으로 이동"
+                      onClick={() => goCalendarWith(s.date)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === "Enter" || ev.key === " ") goCalendarWith(s.date);
+                      }}
+                    >
+                      {formatKDate(s.date)}
+                    </div>
                   </div>
                 );
               })}
+
               {(!stars || stars.length === 0) && (
                 <div className="px-6 py-8 text-neutral-500 text-sm">기록이 없습니다.</div>
               )}

--- a/src/components/ArchiveCard/ConstellationDetailModal.jsx
+++ b/src/components/ArchiveCard/ConstellationDetailModal.jsx
@@ -53,10 +53,42 @@ function pick(obj, keys, def = 0) {
   return def;
 }
 
-function formatKDate(iso) {
-  if (!iso) return "-";
-  const d = new Date(iso);
-  if (isNaN(d)) return "-";
+
+function toDate(input) {
+  if (!input) return null;
+  if (input instanceof Date) return isNaN(input.getTime()) ? null : input;
+
+
+  if (typeof input === "number") {
+    const d = new Date(input);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+
+  if (typeof input === "string") {
+    const s0 = input.trim();
+    if (!s0) return null;
+
+ 
+    const s =
+      s0.length >= 10
+        ? s0.slice(0, 10).replace(/[./]/g, "-")
+        : s0.replace(/[./]/g, "-");
+
+    const d = new Date(s);
+    if (!isNaN(d.getTime())) return d;
+
+
+    const d2 = new Date(s0);
+    return isNaN(d2.getTime()) ? null : d2;
+  }
+
+  return null;
+}
+
+function formatKDate(input) {
+  const d = toDate(input);
+  if (!d) return "-";
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -64,9 +96,8 @@ function formatKDate(iso) {
 }
 
 function toISODate(input) {
-  if (!input) return null;
-  const d = typeof input === "string" ? new Date(input) : input;
-  if (isNaN(d?.getTime?.())) return null;
+  const d = toDate(input);
+  if (!d) return null;
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
@@ -92,14 +123,46 @@ export default function ConstellationDetailModal({
 
   const navigate = useNavigate();
 
-  const hasList = Array.isArray(items) && items.length > 0;
-  const model = hasList && items?.[index] ? items[index] : (detail || initial || {});
-  const { name, description, date, stars = [], connections = [] } = model || {};
+const hasList = Array.isArray(items) && items.length > 0;
+const listItem = hasList && items?.[index] ? items[index] : (initial || {});
+
+
+const detailed = (detail && detail.constellation) ? detail.constellation : detail;
+
+
+const idOf = (x) => x?.constellationId ?? x?.id;
+const same = detailed && listItem && idOf(detailed) && idOf(detailed) === idOf(listItem);
+
+const model = same ? { ...listItem, ...detailed } : (listItem ?? detailed ?? {});
+
+  const { name, description, date, stars = [], connections = [] } = model;
+
+  const total = hasList ? items.length : 0;
+  const canNav = total > 1;
+
+  const goIdx = (next) => {
+    if (!canNav || !onChangeIndex) return;
+    const n = loop ? (next + total) % total : Math.min(Math.max(next, 0), total - 1);
+    onChangeIndex(n);
+  };
+  const goPrev = () => goIdx(index - 1);
+  const goNext = () => goIdx(index + 1);
+
+  React.useEffect(() => {
+    const onKey = (e) => {
+      if (!open) return;
+      if (e.key === "ArrowLeft")  { e.preventDefault(); goPrev(); }
+      if (e.key === "ArrowRight") { e.preventDefault(); goNext(); }
+      if (e.key === "Escape")     onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, index, total]);
 
   function resolveEmotionFromStar(s) {
     const explicit = s?.emotion || s?.emotionType || s?.mood;
     if (explicit) return explicit;
-    const colorKey = String(s?.color || "").toUpperCase();
+    const colorKey = (s?.color || "").toUpperCase();
     return COLOR_TO_EMOTION[colorKey] || null;
   }
 
@@ -132,49 +195,43 @@ export default function ConstellationDetailModal({
     onClose?.();
   };
 
-  const total = hasList ? items.length : 1;
-  const canNav = total > 1;
 
-  const goIdx = (next) => {
-    if (!canNav || !onChangeIndex) return;
-    const n = loop ? (next + total) % total : Math.min(Math.max(next, 0), total - 1);
-    onChangeIndex(n);
-  };
-  const goPrev = () => goIdx(index - 1);
-  const goNext = () => goIdx(index + 1);
+  const headerDate =
+    model?.date ??
+    model?.createdAt ??
+    model?.constellationCreatedAt ??
+    (Array.isArray(stars) && stars[0]?.date) ??
+    null;
 
-  React.useEffect(() => {
-    const onKey = (e) => {
-      if (!open) return;
-      if (e.key === "ArrowLeft") { e.preventDefault(); goPrev(); }
-      if (e.key === "ArrowRight") { e.preventDefault(); goNext(); }
-      if (e.key === "Escape") onClose?.();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, index, total]);
+  const getRowDate = (s) =>
+    s?.date ??
+    s?.createdAt ??
+    s?.created_at ??
+    s?.createdDate ??
+    s?.created_date ??
+    s?.dateStr ??
+    model?.createdAt ??
+    model?.constellationCreatedAt ??
+    null;
 
   return (
     <div className="fixed inset-0 z-[100]">
       <div className="absolute inset-0 bg-black/60" onClick={onClose} aria-hidden="true" />
-      <div className="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
                       bg-white/85 text-neutral-900 w-280 max-w-[95vw] rounded-2xl shadow-2xl relative">
-        {canNav && ( // 방향키 버튼으로 별자리 상세페이지 이동
+        {canNav && (
           <>
             <button
               aria-label="이전 별자리"
               onClick={(e) => { e.stopPropagation(); goPrev(); }}
-              className="absolute left-[-80px] top-1/2 -translate-y-1/2
-                         flex items-center justify-center select-none"
+              className="absolute left-[-80px] top-1/2 -translate-y-1/2 flex items-center justify-center select-none"
             >
-              <span className="text-white text-8xl leading-none  hover:text-gray-300">‹</span>
+              <span className="text-white text-8xl leading-none hover:text-gray-300">‹</span>
             </button>
             <button
               aria-label="다음 별자리"
               onClick={(e) => { e.stopPropagation(); goNext(); }}
-              className="absolute right-[-80px] top-1/2 -translate-y-1/2
-                          flex items-center justify-center select-none"
+              className="absolute right-[-80px] top-1/2 -translate-y-1/2 flex items-center justify-center select-none"
             >
               <span className="text-white text-8xl leading-none hover:text-gray-300">›</span>
             </button>
@@ -204,8 +261,8 @@ export default function ConstellationDetailModal({
           <div className="flex flex-col flex-1">
             <div className="flex items-start justify-between">
               <div>
-                <div className="text-neutral-500 mt-5">{formatKDate(date)}</div>
-                <div className="text-3xl font-bold mt-1">{name || ""}</div>
+                <div className="text-neutral-500 mt-5">{formatKDate(headerDate)}</div>
+                <div className="text-3xl font-bold mt-1">{name}</div>
               </div>
               <button
                 onClick={onClose}
@@ -240,7 +297,7 @@ export default function ConstellationDetailModal({
           </div>
         </div>
 
-        <div className=" bg-neutral-50" />
+        <div className="bg-neutral-50" />
 
         <div className="p-6 font-pretendard">
           <div className="font-semibold mb-3 text-[#4F4F4F]/80 text-xl">내가 남긴 기록 보기</div>
@@ -252,12 +309,13 @@ export default function ConstellationDetailModal({
               <div>생성 날짜</div>
             </div>
 
-            <div className="max-h-50 overflow-y-au>to divide-y divide-[#D9D9D9]">
+            <div className="max-h-50 overflow-y-auto divide-y divide-[#D9D9D9]">
               {(stars || []).map((s) => {
-                const colorKey = String(s?.color || "").toUpperCase();
+                const colorKey = (s?.color || "").toUpperCase();
                 const icon = colorIconMap[colorKey] || yellowColorIcon;
                 const e = resolveEmotionFromStar(s);
                 const key = s?.starId || s?.id;
+                const rowDate = getRowDate(s);
 
                 return (
                   <div key={key} className="grid grid-cols-3 items-center px-6 py-3 bg-[#EBEBEB]">
@@ -269,12 +327,12 @@ export default function ConstellationDetailModal({
                       role="button"
                       tabIndex={0}
                       aria-label="해당 날짜 일기장으로 이동"
-                      onClick={() => goCalendarWith(s?.date)}
+                      onClick={() => goCalendarWith(rowDate)}
                       onKeyDown={(ev) => {
-                        if (ev.key === "Enter" || ev.key === " ") goCalendarWith(s?.date);
+                        if (ev.key === "Enter" || ev.key === " ") goCalendarWith(rowDate);
                       }}
                     >
-                      {formatKDate(s?.date)}
+                      {formatKDate(rowDate)}
                     </div>
                   </div>
                 );

--- a/src/components/ArchiveCard/StarArchiveCard.jsx
+++ b/src/components/ArchiveCard/StarArchiveCard.jsx
@@ -2,8 +2,8 @@ import React from "react";
 import { IoIosStar } from "react-icons/io";
 import ConstellationMini from "../ConstellationMini";
 
-export default function StarArchiveCard({ item, onStarClick }) {
-  const date = new Date(item.date);
+export default function StarArchiveCard({ item, onStarClick, onOpen }) {
+  const date = new Date(item.date || item.createdAt || item.constellationCreatedAt);
   const dateStr =
     `${date.getFullYear()}.` +
     `${String(date.getMonth() + 1).padStart(2, "0")}.` +
@@ -13,6 +13,12 @@ export default function StarArchiveCard({ item, onStarClick }) {
     <div
       className="relative flex flex-row text-white border w-[600px] h-[250px]
                  bg-white/10 border-white/10 rounded-[15px] cursor-pointer"
+      onClick={onOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onOpen?.();
+      }}
     >
       <div className="ml-5 my-4 rounded-[12px]">
         <ConstellationMini
@@ -26,7 +32,7 @@ export default function StarArchiveCard({ item, onStarClick }) {
       <div className="flex flex-col px-5 w-full">
         <div className="text-sm text-white/70 mt-18">{dateStr}</div>
         <div className="text-2xl font-semibold">{item.name}</div>
-        <div className="text-white mt-4">{item.description}</div>
+        <div className="text-white mt-4 line-clamp-3">{item.description}</div>
       </div>
 
       <div className="absolute right-3 top-3 ">
@@ -40,7 +46,11 @@ export default function StarArchiveCard({ item, onStarClick }) {
         >
           <IoIosStar
             size={38}
-            className={item.isRepresentative ? "cursor-pointer text-[#FFD12B]" : "text-white/30 cursor-pointer"}
+            className={
+              item.isRepresentative
+                ? "cursor-pointer text-[#FFD12B]"
+                : "text-white/30 cursor-pointer"
+            }
           />
         </button>
       </div>

--- a/src/components/ArchiveCard/StarArchiveCard.jsx
+++ b/src/components/ArchiveCard/StarArchiveCard.jsx
@@ -2,12 +2,29 @@ import React from "react";
 import { IoIosStar } from "react-icons/io";
 import ConstellationMini from "../ConstellationMini";
 
+function formatCardDate(input) {
+  if (!input) return "-";
+  const s = typeof input === "string" ? input.replace(/[./]/g, "-").slice(0, 10) : input;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return "-";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}.${m}.${day}`;
+}
+
 export default function StarArchiveCard({ item, onStarClick, onOpen }) {
-  const date = new Date(item.date || item.createdAt || item.constellationCreatedAt);
-  const dateStr =
-    `${date.getFullYear()}.` +
-    `${String(date.getMonth() + 1).padStart(2, "0")}.` +
-    `${String(date.getDate()).padStart(2, "0")}`;
+  if (!item) return null;
+
+
+  const rawDate =
+    item.date ||
+    item.createdAt ||
+    item.constellationCreatedAt ||
+    item.constellation?.date ||
+    item.constellation?.createdAt;
+
+  const dateStr = formatCardDate(rawDate);
 
   return (
     <div

--- a/src/components/ConstellationModal.jsx
+++ b/src/components/ConstellationModal.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 
+import backgroundImg from "../assets/background.png";
+
 const MIN_NODES = 7;
 const MAX_NODES = 14;
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
 
 const ConstellationModal = ({
   open,
@@ -11,6 +14,7 @@ const ConstellationModal = ({
   stars = [],
   colorImageMap = {},
 }) => {
+  const [step, setStep] = useState(1);
   const [name, setName] = useState(initial?.name ?? "");
   const [desc, setDesc] = useState(initial?.desc ?? "");
   const [starPositions, setStarPositions] = useState({});
@@ -21,7 +25,6 @@ const ConstellationModal = ({
   const panelRef = useRef(null);
   const dragIdRef = useRef(null);
 
-  const clamp01 = (v) => Math.max(0, Math.min(1, v));
   const toRel = (clientX, clientY) => {
     const r = panelRef.current.getBoundingClientRect();
     return {
@@ -33,6 +36,7 @@ const ConstellationModal = ({
   useEffect(() => {
     if (!open) return;
 
+    setStep(1);
     setName(initial?.name ?? "");
     setDesc(initial?.desc ?? "");
     setWarn("");
@@ -44,8 +48,9 @@ const ConstellationModal = ({
         y: typeof s.y === "number" ? clamp01(s.y) : 0.5,
       };
     });
+
     setStarPositions(init);
-    setEdges([]);
+    setEdges(initial?.lines ?? []);
     setSelectedStar(null);
 
     document.body.style.overflow = "hidden";
@@ -62,19 +67,23 @@ const ConstellationModal = ({
   }, []);
 
   const onPointerDownStar = (e, id) => {
+    if (step !== 1) return;
     e.preventDefault();
     e.stopPropagation();
     setWarn("");
+
     dragIdRef.current = id;
     window.addEventListener("pointermove", onPointerMove, { passive: false });
     window.addEventListener("pointerup", onPointerUp, { passive: true });
   };
 
   const onPointerMove = (e) => {
-    if (!dragIdRef.current || !panelRef.current) return;
+    if (!dragIdRef.current || !panelRef.current || step !== 1) return;
     e.preventDefault();
+
     const { x, y } = toRel(e.clientX, e.clientY);
     const id = dragIdRef.current;
+
     setStarPositions((prev) => ({ ...prev, [id]: { x, y } }));
   };
 
@@ -82,25 +91,6 @@ const ConstellationModal = ({
     dragIdRef.current = null;
     window.removeEventListener("pointermove", onPointerMove);
     window.removeEventListener("pointerup", onPointerUp);
-  };
-
-  const willFormCycle = (a, b, currentEdges) => {
-    const parent = {};
-    const find = (x) => {
-      if (parent[x] == null) parent[x] = x;
-      if (parent[x] === x) return x;
-      parent[x] = find(parent[x]);
-      return parent[x];
-    };
-    const union = (x, y) => {
-      const rx = find(x);
-      const ry = find(y);
-      if (rx === ry) return false;
-      parent[ry] = rx;
-      return true;
-    };
-    for (const [u, v] of currentEdges) union(u, v);
-    return find(a) === find(b);
   };
 
   const addEdgeIfValid = (a, b) => {
@@ -111,14 +101,10 @@ const ConstellationModal = ({
     );
     if (exists) return;
 
-    if (willFormCycle(a, b, edges)) {
-      setWarn("선이 순환(사이클)되면 안 돼요. 다른 별을 선택해보세요.");
-      return;
-    }
-
     const nodeSet = new Set(edges.flat());
     nodeSet.add(a);
     nodeSet.add(b);
+
     if (nodeSet.size > MAX_NODES) {
       setWarn(`연결된 별은 최대 ${MAX_NODES}개까지예요.`);
       return;
@@ -126,20 +112,24 @@ const ConstellationModal = ({
 
     setEdges((prev) => [...prev, [a, b]]);
     setWarn("");
+    setSelectedStar(null);
   };
 
   const onClickStar = (id) => {
+    if (step !== 1) return;
+
     if (!selectedStar) {
       setSelectedStar(id);
       setWarn("");
       return;
     }
+
     if (selectedStar === id) {
       setSelectedStar(null);
       return;
     }
+
     addEdgeIfValid(selectedStar, id);
-    setSelectedStar(null);
   };
 
   const removeLastLine = () => {
@@ -152,20 +142,35 @@ const ConstellationModal = ({
     setEdges([]);
   };
 
-  const submit = () => {
-    const nodeSet = new Set(edges.flat());
-    const cnt = nodeSet.size;
-    if (cnt < MIN_NODES || cnt > MAX_NODES) {
+  const nodeCount = new Set(edges.flat()).size;
+
+  const goNext = () => {
+    if (nodeCount < MIN_NODES || nodeCount > MAX_NODES) {
       setWarn(
-        `별자리는 연결된 별이 ${MIN_NODES}~${MAX_NODES}개여야 해요. (현재: ${cnt}개)`
+        `별자리는 연결된 별이 ${MIN_NODES}~${MAX_NODES}개여야 해요. (현재: ${nodeCount}개)`
       );
       return;
     }
+
+    setWarn("");
+    setSelectedStar(null);
+    setStep(2);
+  };
+
+  const canFinish = name.trim().length > 0 && desc.trim().length > 0;
+
+  const finish = () => {
+    if (!canFinish) return;
+
+    const createdAt =
+      initial?.constellationCreatedAt || new Date().toISOString();
+
     onSubmit?.({
       name: name.trim(),
       desc: desc.trim(),
       lines: edges,
       starPositions,
+      constellationCreatedAt: createdAt,
     });
   };
 
@@ -177,166 +182,215 @@ const ConstellationModal = ({
       role="dialog"
       aria-modal="true"
       style={{
-        background:
-          "radial-gradient(circle at 10% 10%, rgba(255,255,255,0.12) 0%, rgba(5,21,48,1) 45%, rgba(5,21,48,1) 100%)",
+        background: "rgba(0,0,0,0.28)",
+        backdropFilter: "blur(2px)",
       }}
     >
-      <div
-        className="absolute inset-0"
-        onClick={onClose}
-        aria-hidden="true"
-        style={{ backdropFilter: "blur(1px)" }}
-      />
+      <div className="absolute inset-0" onClick={onClose} aria-hidden="true" />
 
       <div
-        className="relative w-[1180px] max-w-[95vw] h-[650px] rounded-[28px] shadow-[0_20px_60px_rgba(0,0,0,0.35)] border border-white/25 flex"
+        className="relative w-[950px] max-w-[96vw] rounded-[26px] flex flex-col"
         style={{
-          background:
-            "linear-gradient(180deg, rgba(246,247,250,0.3) 0%, rgba(237,239,242,0.35) 50%, rgba(232,233,236,0.2) 100%)",
-          backdropFilter: "blur(16px)",
+          backgroundColor: "#f3f4f6",
+          boxShadow: "0 14px 40px rgba(0,0,0,0.35)",
         }}
+        onClick={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={onClose}
-          className="absolute right-8 top-7 text-black/70 hover:text-black text-3xl"
-          aria-label="닫기"
+        <div
+          className="flex items-center justify-between px-7 h-[64px] rounded-t-[26px]"
+          style={{
+            backgroundColor: "#e4e5e7",
+            borderBottom: "1px solid rgba(0,0,0,0.08)",
+          }}
         >
-          ←
-        </button>
-
-        <div className="w-[48%] h-full flex flex-col px-7 py-6">
-          <div
-            ref={panelRef}
-            className="relative flex-1 rounded-[20px] bg-[#dcdfe5]/60 border-[3px] border-[#b7b4b7]/80 overflow-hidden"
-            style={{
-              backgroundImage:
-                "radial-gradient(circle, rgba(255,255,255,0.25) 1px, transparent 1px)",
-              backgroundSize: "60px 60px",
-              boxShadow: "inset 0 0 20px rgba(0,0,0,0.05)",
-              touchAction: "none",
+          <button
+            onClick={() => {
+              if (step === 1) onClose?.();
+              else {
+                setStep(1);
+                setWarn("");
+                setSelectedStar(null);
+              }
             }}
+            className="text-[24px] text-black/70 hover:text-black leading-none"
           >
-            <svg className="absolute inset-0 w-full h-full pointer-events-none">
-              {edges.map(([a, b], idx) => {
-                const pa = starPositions[a];
-                const pb = starPositions[b];
-                if (!pa || !pb) return null;
-                return (
-                  <line
-                    key={idx}
-                    x1={`${pa.x * 100}%`}
-                    y1={`${pa.y * 100}%`}
-                    x2={`${pb.x * 100}%`}
-                    y2={`${pb.y * 100}%`}
-                    stroke="#000000"
-                    strokeOpacity="0.9"
-                    strokeWidth="2.3"
-                    strokeLinecap="round"
-                  />
-                );
-              })}
-            </svg>
+            {step === 1 ? "×" : "←"}
+          </button>
 
-            {stars.map((s) => {
-              const p = starPositions[s.id];
-              if (!p) return null;
-              const imgSrc = colorImageMap[s.color];
-              if (!imgSrc) return null;
-              const selected = selectedStar === s.id;
-              return (
-                <img
-                  key={s.id}
-                  src={imgSrc}
-                  alt={s.color}
-                  draggable={false}
-                  onPointerDown={(e) => onPointerDownStar(e, s.id)}
-                  onClick={() => onClickStar(s.id)}
-                  style={{
-                    position: "absolute",
-                    left: `${p.x * 100}%`,
-                    top: `${p.y * 100}%`,
-                    transform: "translate(-50%, -50%)",
-                    width: 24,
-                    height: 24,
-                    userSelect: "none",
-                    touchAction: "none",
-                    cursor: "grab",
-                    filter: selected
-                      ? "drop-shadow(0 0 6px rgba(17,24,39,.6))"
-                      : "none",
-                  }}
-                />
-              );
-            })}
+          <div className="text-[20px] font-semibold text-black">
+            별자리 생성
           </div>
 
-          <div className="mt-3 flex items-center justify-between gap-3">
-            <p className="text-[13px] text-black/65">
-              별을 끌어 이동하고, 서로 클릭해 선을 이어보세요.
-            </p>
-            <div className="flex gap-2">
-              <button
-                onClick={removeLastLine}
-                disabled={edges.length === 0}
-                className={`px-3 py-1.5 text-[12px] rounded-lg border ${
-                  edges.length === 0
-                    ? "bg-white/60 text-black/30 border-black/5"
-                    : "bg-white/90 text-black/70 hover:bg-white border-black/10"
-                }`}
-              >
-                마지막 선 지우기
-              </button>
-              <button
-                onClick={clearLines}
-                disabled={edges.length === 0}
-                className={`px-3 py-1.5 text-[12px] rounded-lg border ${
-                  edges.length === 0
-                    ? "bg-white/60 text-black/30 border-black/5"
-                    : "bg-white/90 text-black/70 hover:bg-white border-black/10"
-                }`}
-              >
-                전체 선 지우기
-              </button>
-            </div>
-          </div>
-
-          {warn && (
-            <div className="mt-2 text-[12px] text-red-700 bg-red-50/80 border border-red-200 px-3 py-2 rounded-lg">
-              {warn}
-            </div>
+          {step === 1 ? (
+            <button
+              onClick={goNext}
+              className="text-[15px] font-semibold text-[#111827]"
+            >
+              다음
+            </button>
+          ) : (
+            <button
+              onClick={finish}
+              disabled={!canFinish}
+              className={`text-[15px] font-semibold ${
+                canFinish
+                  ? "text-[#111827]"
+                  : "text-black/30 cursor-not-allowed"
+              }`}
+            >
+              완료
+            </button>
           )}
         </div>
 
-        <div className="w-[52%] h-full flex flex-col items-center justify-center px-10 gap-6">
-          <h2 className="text-[30px] font-extrabold text-black tracking-tight text-center">
-            별자리 이름을 지정해주세요
-          </h2>
+        <div className="flex flex-col items-center px-10 py-6 gap-4">
+          {step === 1 && (
+            <p className="text-[13px] text-black/60">
+              *별을 끌어 이동하고, 서로 연결하여 별자리를 완성해보세요
+            </p>
+          )}
 
-          <div className="w-full flex flex-col gap-4 max-w-[460px]">
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="미지정 별자리"
-              className="w-full h-[54px] rounded-full bg-white/90 px-6 text-[15px] text-black outline-none border border-white/0 focus:border-[#146b5b]/50 shadow-[0_4px_18px_rgba(0,0,0,0.04)]"
-            />
+          <div className="flex flex-col items-center gap-5">
+            <div
+              ref={panelRef}
+              className="relative w-[440px] max-w-full aspect-square rounded-[26px] overflow-hidden"
+              style={{
+                backgroundImage: `url(${backgroundImg})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                border: "1px solid rgba(0,0,0,0.12)",
+              }}
+            >
+              <svg className="absolute inset-0 w-full h-full pointer-events-none">
+                {edges.map(([a, b], idx) => {
+                  const pa = starPositions[a];
+                  const pb = starPositions[b];
+                  if (!pa || !pb) return null;
 
-            <input
-              type="text"
-              value={desc}
-              onChange={(e) => setDesc(e.target.value)}
-              placeholder="별자리에 대한 소개를 작성해주세요"
-              className="w-full h-[54px] rounded-full bg-white/90 px-6 text-[15px] text-black outline-none border border-white/0 focus:border-[#146b5b]/50 shadow-[0_4px_18px_rgba(0,0,0,0.04)]"
-            />
+                  return (
+                    <line
+                      key={idx}
+                      x1={`${pa.x * 100}%`}
+                      y1={`${pa.y * 100}%`}
+                      x2={`${pb.x * 100}%`}
+                      y2={`${pb.y * 100}%`}
+                      stroke="#ffffff"
+                      strokeOpacity="0.95"
+                      strokeWidth="2.2"
+                      strokeLinecap="round"
+                    />
+                  );
+                })}
+              </svg>
+
+              {stars.map((s) => {
+                const p = starPositions[s.id];
+                if (!p) return null;
+
+                const imgSrc = colorImageMap[s.color];
+                if (!imgSrc) return null;
+
+                const isSelected = step === 1 && selectedStar === s.id;
+
+                return (
+                  <img
+                    key={s.id}
+                    src={imgSrc}
+                    alt={s.color}
+                    draggable={false}
+                    onPointerDown={(e) => onPointerDownStar(e, s.id)}
+                    onClick={() => onClickStar(s.id)}
+                    style={{
+                      position: "absolute",
+                      left: `${p.x * 100}%`,
+                      top: `${p.y * 100}%`,
+                      transform: "translate(-50%, -50%)",
+                      width: 22,
+                      height: 22,
+                      userSelect: "none",
+                      touchAction: "none",
+                      cursor: step === 1 ? "grab" : "default",
+                      filter: isSelected
+                        ? "drop-shadow(0 0 8px rgba(255,255,255,0.9))"
+                        : "none",
+                      animation: isSelected
+                        ? "twinkleStar 0.9s ease-in-out infinite alternate"
+                        : "none",
+                      pointerEvents: step === 1 ? "auto" : "none",
+                    }}
+                  />
+                );
+              })}
+            </div>
+
+            {step === 1 && (
+              <div className="flex gap-3">
+                <button
+                  onClick={clearLines}
+                  disabled={edges.length === 0}
+                  className={`px-5 py-2 rounded-[999px] text-[13px] ${
+                    edges.length === 0
+                      ? "bg-[#e5e7eb] text-black/35 cursor-not-allowed"
+                      : "bg-[#e5e7eb] text-black/70 hover:bg-[#d4d7dd]"
+                  }`}
+                >
+                  전체 삭제
+                </button>
+
+                <button
+                  onClick={removeLastLine}
+                  disabled={edges.length === 0}
+                  className={`px-5 py-2 rounded-[999px] text-[13px] ${
+                    edges.length === 0
+                      ? "bg-[#e5e7eb] text-black/35 cursor-not-allowed"
+                      : "bg-[#e5e7eb] text-black/70 hover:bg-[#d4d7dd]"
+                  }`}
+                >
+                  마지막 선 지우기
+                </button>
+              </div>
+            )}
+
+            {step === 2 && (
+              <div className="flex flex-col items-center w-full gap-4">
+                <h2 className="text-[17px] font-semibold text-black/80">
+                  별자리 이름을 지정해주세요
+                </h2>
+
+                <div className="w-[380px] flex flex-col gap-3">
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="미지정 별자리"
+                    className="w-full h-[44px] rounded-full bg-white px-5 text-[14px] text-black outline-none border border-black/10 focus:border-[#4b5563]"
+                  />
+
+                  <input
+                    type="text"
+                    value={desc}
+                    onChange={(e) => setDesc(e.target.value)}
+                    placeholder="별자리에 대한 소개를 작성해주세요"
+                    className="w-full h-[44px] rounded-full bg-white px-5 text-[14px] text-black outline-none border border-black/10 focus:border-[#4b5563]"
+                  />
+                </div>
+              </div>
+            )}
+
+            {warn && (
+              <div className="text-[12px] text-red-700 bg-red-50/80 border border-red-200 px-3 py-2 rounded-lg">
+                {warn}
+              </div>
+            )}
           </div>
-
-          <button
-            onClick={submit}
-            className="mt-2 px-16 py-2.5 rounded-[9999px] bg-[#12561f] hover:bg-[#0f491a] text-white font-semibold tracking-[0.4em]"
-          >
-            설 정
-          </button>
         </div>
+
+        <style>{`
+          @keyframes twinkleStar {
+            0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+            100% { transform: translate(-50%, -50%) scale(1.1); opacity: 0.6; }
+          }
+        `}</style>
       </div>
     </div>
   );

--- a/src/components/StarSkyDate.jsx
+++ b/src/components/StarSkyDate.jsx
@@ -23,6 +23,51 @@ const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 const EDGE_PAD = 0.02;
 const LABEL_TOP_FLIP_Y = 0.1;
 
+function avoidUiZones(nx, ny, rect) {
+  if (!rect) return { x: nx, y: ny };
+  let px = nx * rect.width;
+  let py = ny * rect.height;
+
+  const zones = [
+    { x1: 0, y1: 0, x2: 60, y2: 65 },
+    { x1: rect.width - 115, y1: 0, x2: rect.width, y2: 50 },
+
+    {
+      x1: rect.width / 2 - 160,
+      y1: rect.height - 80,
+      x2: rect.width / 2 + 160,
+      y2: rect.height,
+    },
+  ];
+
+  const margin = 4;
+
+  zones.forEach((z) => {
+    if (px >= z.x1 && px <= z.x2 && py >= z.y1 && py <= z.y2) {
+      const dLeft = px - z.x1;
+      const dRight = z.x2 - px;
+      const dTop = py - z.y1;
+      const dBottom = z.y2 - py;
+
+      const minD = Math.min(dLeft, dRight, dTop, dBottom);
+
+      if (minD === dLeft) {
+        px = z.x1 - margin;
+      } else if (minD === dRight) {
+        px = z.x2 + margin;
+      } else if (minD === dTop) {
+        py = z.y1 - margin;
+      } else {
+        py = z.y2 + margin;
+      }
+    }
+  });
+
+  const nx2 = clampToView(px / rect.width);
+  const ny2 = clampToView(py / rect.height);
+  return { x: nx2, y: ny2 };
+}
+
 function getTodayLocal() {
   const d = new Date();
   const y = d.getFullYear();
@@ -174,25 +219,22 @@ export default function StarSkyDate({
   useEffect(() => {
     if (!filteredConstellationGroups.length) return;
     const store = constellationCreatedAtRef.current;
-    const today = getTodayLocal();
 
     filteredConstellationGroups.forEach((g) => {
       const id = g.id;
       if (!id) return;
 
       const modalPickedDate =
-        g.constellationDate || g.selectedDate || g.dateFromModal || null;
+        g.constellationCreatedAt ||
+        g.constellationDate ||
+        g.selectedDate ||
+        g.dateFromModal ||
+        g.createdAt ||
+        g.created_at ||
+        null;
 
-      if (!store[id]) {
-        if (modalPickedDate) {
-          store[id] = String(modalPickedDate).slice(0, 10);
-        } else {
-          store[id] = today;
-        }
-      } else {
-        if (modalPickedDate) {
-          store[id] = String(modalPickedDate).slice(0, 10);
-        }
+      if (modalPickedDate) {
+        store[id] = String(modalPickedDate).slice(0, 10);
       }
     });
   }, [filteredConstellationGroups]);
@@ -205,7 +247,7 @@ export default function StarSkyDate({
   const [starDrag, setStarDrag] = useState(null);
   const [hover, setHover] = useState({ show: false, x: 0, y: 0 });
 
-  const [scaleUI, setScaleUI] = useState(0.5);
+  const [scaleUI, setScaleUI] = useState(1.0);
   const scaleRef = useRef(1);
   const didInitialScaleRef = useRef(false);
   const committedMapRef = useRef(null);
@@ -244,29 +286,80 @@ export default function StarSkyDate({
     prevMultipleRef.current = multipleMode;
   }, [multipleMode]);
 
+  const multiBaseSizeRef = useRef(null);
+  const multiNormalizedRef = useRef({});
+
   useEffect(() => {
     if (!multipleMode) return;
+
+    let changed = false;
+    const baseStore = baseConstShapesRef.current;
+    const normalized = multiNormalizedRef.current;
+
     filteredConstellationGroups.forEach((g) => {
       const id = g.id;
       if (!id) return;
-      if (!baseConstShapesRef.current[id]) {
+
+      if (!baseStore[id]) {
         const base = {};
         (g.stars || []).forEach((s) => {
           const realId = s.id ?? s.starId;
           base[realId] = { x: s.x, y: s.y };
         });
-        baseConstShapesRef.current[id] = ensureMinSize(base, 0.12);
+        const normalizedBase = ensureMinSize(base, 0.12);
+        baseStore[id] = normalizedBase;
+        changed = true;
+      }
+
+      const base = baseStore[id];
+      const box = computeBBoxFromPoints(Object.values(base));
+      if (!box) return;
+
+      if (multiBaseSizeRef.current == null) {
+        multiBaseSizeRef.current = Math.max(box.w, box.h);
+      }
+
+      const targetSize = multiBaseSizeRef.current;
+      const curSize = Math.max(box.w, box.h) || 0.0001;
+      const factor = targetSize / curSize;
+
+      if (!normalized[id]) {
+        let scaled = base;
+        if (Math.abs(factor - 1) > 1e-3) {
+          const scaledMap = {};
+          Object.entries(base).forEach(([starId, p]) => {
+            const dx = p.x - box.cx;
+            const dy = p.y - box.cy;
+            scaledMap[starId] = {
+              x: box.cx + dx * factor,
+              y: box.cy + dy * factor,
+            };
+          });
+          scaled = scaledMap;
+        }
+
+        baseStore[id] = scaled;
+        normalized[id] = true;
+
+        if (!appliedMapRef.current[id]) {
+          appliedMapRef.current[id] = deepClone(scaled);
+        }
+        changed = true;
       }
     });
+
+    if (changed) {
+      setAppliedVersion((v) => v + 1);
+    }
   }, [multipleMode, filteredConstellationGroups]);
 
   const positionOf = (s) => {
+    if (previewMap && previewMap[s.id]) {
+      return previewMap[s.id];
+    }
     const appliedSingle = appliedMapRef.current["single"];
     if (appliedSingle && appliedSingle[s.id]) {
       return appliedSingle[s.id];
-    }
-    if (previewMap && previewMap[s.id]) {
-      return previewMap[s.id];
     }
     return { x: s.x, y: s.y };
   };
@@ -295,15 +388,32 @@ export default function StarSkyDate({
       );
       const base = ensureMinSize(baseRaw, 0.12);
 
-      committedMapRef.current = base;
-      appliedMapRef.current["single"] = base;
-      scaleRef.current = 1;
-      singleScaleOriginRef.current = null;
-      setScaleUI(initialScaleOnLock);
-      applyScalePreviewSingle(initialScaleOnLock, {
-        commit: true,
-        forceFromScale: 1,
-      });
+      singleScaleOriginRef.current = base;
+      const clampedInit = 1.0;
+      scaleRef.current = clampedInit;
+      setScaleUI(clampedInit);
+
+      const baseBox = computeBBoxFromPoints(Object.values(base));
+      let initialMap = base;
+      if (baseBox) {
+        const { cx, cy } = baseBox;
+        const sAbs = clampedInit;
+        initialMap = {};
+        Object.entries(base).forEach(([id, p]) => {
+          const dx = p.x - cx;
+          const dy = p.y - cy;
+          initialMap[id] = {
+            x: cx + dx * sAbs,
+            y: cy + dy * sAbs,
+          };
+        });
+        initialMap = fitMapIntoView(initialMap, 0);
+      }
+
+      appliedMapRef.current["single"] = initialMap;
+      setPreviewMap(null);
+      onTransform?.(initialMap);
+      onTransformEnd?.(initialMap);
       setIsSelected(false);
       setAppliedVersion((v) => v + 1);
     }
@@ -313,7 +423,7 @@ export default function StarSkyDate({
       committedMapRef.current = null;
       setPreviewMap(null);
       setIsSelected(false);
-      setScaleUI(0.5);
+      setScaleUI(1.0);
       scaleRef.current = 1;
       appliedMapRef.current = {};
       singleScaleOriginRef.current = null;
@@ -329,6 +439,8 @@ export default function StarSkyDate({
     initialScaleOnLock,
     filteredConstellationGroups,
     multipleMode,
+    onTransform,
+    onTransformEnd,
   ]);
 
   const toRel = (clientX, clientY) => {
@@ -337,6 +449,33 @@ export default function StarSkyDate({
       x: clamp01((clientX - r.left) / r.width),
       y: clamp01((clientY - r.top) / r.height),
     };
+  };
+
+  const getConstellationMapForDrag = (constellation) => {
+    const constId = constellation.id;
+    const appliedForThis = appliedMapRef.current[constId];
+    const baseMap = baseConstShapesRef.current[constId];
+    const usePreview = previewMap && constId === activeConstellationId;
+
+    const map = {};
+    (constellation.stars || []).forEach((s) => {
+      const key = s.id ?? s.starId;
+      let p = null;
+
+      if (usePreview && previewMap[key]) {
+        p = previewMap[key];
+      } else if (appliedForThis && appliedForThis[key]) {
+        p = appliedForThis[key];
+      } else if (baseMap && baseMap[key]) {
+        p = baseMap[key];
+      } else {
+        p = { x: s.x, y: s.y };
+      }
+
+      map[key] = { x: p.x, y: p.y };
+    });
+
+    return map;
   };
 
   const startMoveDragSingle = (e) => {
@@ -351,7 +490,6 @@ export default function StarSkyDate({
     const baseMap =
       previewMap ||
       appliedMapRef.current["single"] ||
-      committedMapRef.current ||
       Object.fromEntries(filteredStars.map((s) => [s.id, { x: s.x, y: s.y }]));
 
     groupDragRef.current = {
@@ -363,9 +501,6 @@ export default function StarSkyDate({
     };
 
     setIsSelected(true);
-    setPendingApply(true);
-    originalPositionRef.current = deepClone(baseMap);
-    singleScaleOriginRef.current = deepClone(baseMap);
   };
 
   const startMoveDragConstellation = (e, constellation) => {
@@ -375,38 +510,11 @@ export default function StarSkyDate({
     try {
       e.currentTarget?.setPointerCapture?.(e.pointerId);
     } catch {}
-    const startRel = toRel(e.clientX, e.clientY);
+
     const constId = constellation.id;
+    const startRel = toRel(e.clientX, e.clientY);
 
-    const previewForThis =
-      previewMap && constId === activeConstellationId ? previewMap : null;
-    const appliedForThis = appliedMapRef.current[constId];
-
-    let originMap = {};
-
-    if (previewForThis) {
-      Object.entries(previewForThis).forEach(([id, p]) => {
-        originMap[id] = { x: p.x, y: p.y };
-      });
-    } else if (appliedForThis) {
-      Object.entries(appliedForThis).forEach(([id, p]) => {
-        originMap[id] = { x: p.x, y: p.y };
-      });
-    } else if (committedConstMapRef.current[constId]) {
-      originMap = deepClone(committedConstMapRef.current[constId]);
-    } else {
-      (constellation.stars || []).forEach((s) => {
-        const realId = s.id || s.starId;
-        originMap[realId] = {
-          x: clampToView(s.x),
-          y: clampToView(s.y),
-        };
-      });
-      originMap = ensureMinSize(originMap, 0.12);
-    }
-
-    committedConstMapRef.current[constId] = deepClone(originMap);
-
+    const originMap = getConstellationMapForDrag(constellation);
     const bbox0 = computeBBoxFromPoints(Object.values(originMap));
 
     groupDragRef.current = {
@@ -464,11 +572,9 @@ export default function StarSkyDate({
 
     if (drag.mode === "single") {
       if (previewMap) {
-        singleScaleOriginRef.current = deepClone(previewMap);
-      } else if (appliedMapRef.current["single"]) {
-        singleScaleOriginRef.current = deepClone(
-          appliedMapRef.current["single"]
-        );
+        appliedMapRef.current["single"] = deepClone(previewMap);
+        onTransformEnd?.(previewMap);
+        setAppliedVersion((v) => v + 1);
       }
     } else if (drag.mode === "multi") {
       const constId = drag.constellationId;
@@ -498,8 +604,12 @@ export default function StarSkyDate({
 
     if (pendingApply) {
       if (originalPositionRef.current) {
+        appliedMapRef.current["single"] = deepClone(
+          originalPositionRef.current
+        );
         setPreviewMap(null);
         onTransformEnd?.(originalPositionRef.current);
+        setAppliedVersion((v) => v + 1);
       }
       setPendingApply(false);
     }
@@ -511,7 +621,12 @@ export default function StarSkyDate({
     try {
       e.currentTarget.setPointerCapture?.(e.pointerId);
     } catch {}
-    const cur = previewMap?.[star.id] ?? { x: star.x, y: star.y };
+    const cur = (previewMap && previewMap[star.id]) ||
+      (appliedMapRef.current["single"] &&
+        appliedMapRef.current["single"][star.id]) || {
+        x: star.x,
+        y: star.y,
+      };
     setStarDrag({
       id: star.id,
       startXpx: e.clientX,
@@ -532,11 +647,16 @@ export default function StarSkyDate({
     const moved =
       starDrag.moved || Math.hypot(dxPx, dyPx) >= DRAG_SELECT_THRESHOLD_PX;
 
-    const nx = clampToView(starDrag.originPos.x + dxPx / r.width);
-    const ny = clampToView(starDrag.originPos.y + dyPx / r.height);
+    let nx = clampToView(starDrag.originPos.x + dxPx / r.width);
+    let ny = clampToView(starDrag.originPos.y + dyPx / r.height);
+
+    const adjusted = avoidUiZones(nx, ny, r);
+    nx = adjusted.x;
+    ny = adjusted.y;
 
     const base =
-      previewMap ??
+      previewMap ||
+      appliedMapRef.current["single"] ||
       Object.fromEntries(filteredStars.map((s) => [s.id, { x: s.x, y: s.y }]));
     const next = { ...base, [star.id]: { x: nx, y: ny } };
 
@@ -577,8 +697,6 @@ export default function StarSkyDate({
     } else {
       if (previewMap) {
         appliedMapRef.current["single"] = deepClone(previewMap);
-        committedMapRef.current = deepClone(previewMap);
-        singleScaleOriginRef.current = deepClone(previewMap);
         setAppliedVersion((v) => v + 1);
       }
     }
@@ -586,53 +704,53 @@ export default function StarSkyDate({
     setStarDrag(null);
   };
 
-  const applyScalePreviewSingle = (
-    newScale,
-    { commit = false, forceFromScale } = {}
-  ) => {
-    const sAbs = Math.max(0.2, Math.min(1.0, newScale));
+  const applyScalePreviewSingle = (newScale, { commit = false } = {}) => {
+    const sAbs = Math.max(0.5, Math.min(1.5, newScale));
 
-    let origin = singleScaleOriginRef.current;
-
-    if (!origin) {
-      const rawBase =
-        previewMap ||
-        appliedMapRef.current["single"] ||
-        committedMapRef.current ||
-        Object.fromEntries(
-          filteredStars.map((s) => [s.id, { x: s.x, y: s.y }])
-        );
-
-      origin = ensureMinSize(rawBase, 0.12);
-      singleScaleOriginRef.current = origin;
+    let base = singleScaleOriginRef.current;
+    if (!base) {
+      const rawBase = Object.fromEntries(
+        filteredStars.map((s) => [s.id, { x: s.x, y: s.y }])
+      );
+      base = ensureMinSize(rawBase, 0.12);
+      singleScaleOriginRef.current = base;
     }
 
-    const pts = Object.values(origin);
-    const bbox = computeBBoxFromPoints(pts);
-    if (!bbox) return;
-    const { cx, cy } = bbox;
+    const baseBox = computeBBoxFromPoints(Object.values(base));
+    if (!baseBox) return;
+
+    const currentApplied = appliedMapRef.current["single"] || base;
+    const currentForCenter = previewMap || currentApplied;
+    const committedBox = computeBBoxFromPoints(Object.values(currentForCenter));
+
+    const tx = committedBox && baseBox ? committedBox.cx - baseBox.cx : 0;
+    const ty = committedBox && baseBox ? committedBox.cy - baseBox.cy : 0;
 
     const scaled = {};
-    Object.entries(origin).forEach(([id, p]) => {
-      const dx = p.x - cx;
-      const dy = p.y - cy;
+    Object.entries(base).forEach(([id, p]) => {
+      const dx = p.x - baseBox.cx;
+      const dy = p.y - baseBox.cy;
       scaled[id] = {
-        x: cx + dx * sAbs,
-        y: cy + dy * sAbs,
+        x: baseBox.cx + dx * sAbs + tx,
+        y: baseBox.cy + dy * sAbs + ty,
       };
     });
 
     const fitted = fitMapIntoView(scaled, 0);
+
+    if (!pendingApply) {
+      const original = appliedMapRef.current["single"] || currentForCenter;
+      originalPositionRef.current = deepClone(original);
+    }
 
     setPreviewMap(fitted);
     onTransform?.(fitted);
     setPendingApply(true);
 
     if (commit) {
-      committedMapRef.current = fitted;
-      appliedMapRef.current["single"] = fitted;
+      appliedMapRef.current["single"] = deepClone(fitted);
       scaleRef.current = sAbs;
-      singleScaleOriginRef.current = deepClone(fitted);
+      setScaleUI(sAbs);
       onTransformEnd?.(fitted);
       setPendingApply(false);
       setAppliedVersion((v) => v + 1);
@@ -655,6 +773,7 @@ export default function StarSkyDate({
   const activeConstBBox = (() => {
     if (!multipleMode || !activeConst) return null;
     const applied = appliedMapRef.current[activeConst.id];
+    const base = baseConstShapesRef.current[activeConst.id];
     const pts = (activeConst.stars || []).map((s) => {
       const id = s.id ?? s.starId;
       if (
@@ -664,6 +783,7 @@ export default function StarSkyDate({
       )
         return previewMap[id];
       if (applied && applied[id]) return applied[id];
+      if (base && base[id]) return base[id];
       return { x: s.x, y: s.y };
     });
     return computeBBoxFromPoints(pts);
@@ -778,6 +898,7 @@ export default function StarSkyDate({
           {multipleMode &&
             filteredConstellationGroups.map((g) => {
               const appliedForThis = appliedMapRef.current[g.id] || null;
+              const baseMap = baseConstShapesRef.current[g.id] || null;
               return (g.connections || []).map((conn, idx) => {
                 const [a, b] = Array.isArray(conn)
                   ? conn
@@ -796,14 +917,16 @@ export default function StarSkyDate({
                 const p1 = (previewMap &&
                   g.id === activeConstellationId &&
                   previewMap[paId]) ||
-                  (appliedForThis && appliedForThis[paId]) || {
+                  (appliedForThis && appliedForThis[paId]) ||
+                  (baseMap && baseMap[paId]) || {
                     x: pa.x,
                     y: pa.y,
                   };
                 const p2 = (previewMap &&
                   g.id === activeConstellationId &&
                   previewMap[pbId]) ||
-                  (appliedForThis && appliedForThis[pbId]) || {
+                  (appliedForThis && appliedForThis[pbId]) ||
+                  (baseMap && baseMap[pbId]) || {
                     x: pb.x,
                     y: pb.y,
                   };
@@ -957,6 +1080,7 @@ export default function StarSkyDate({
         {multipleMode &&
           filteredConstellationGroups.map((g) => {
             const appliedForThis = appliedMapRef.current[g.id] || null;
+            const baseMap = baseConstShapesRef.current[g.id] || null;
             return (g.stars || []).map((s) => {
               const img = colorImageMap[(s.color || "").toUpperCase()];
               if (!img) return null;
@@ -965,7 +1089,8 @@ export default function StarSkyDate({
               const p = (previewMap &&
                 g.id === activeConstellationId &&
                 previewMap[id]) ||
-                (appliedForThis && appliedForThis[id]) || { x: s.x, y: s.y };
+                (appliedForThis && appliedForThis[id]) ||
+                (baseMap && baseMap[id]) || { x: s.x, y: s.y };
 
               const showPulse =
                 locked &&
@@ -1060,10 +1185,11 @@ export default function StarSkyDate({
             }}
           >
             <div>{activeConst.name || "(미지정 별자리)"}</div>
-            <div className="opacity-80">
-              {constellationCreatedAtRef.current[activeConst.id] ||
-                getTodayLocal()}
-            </div>
+            {constellationCreatedAtRef.current[activeConst.id] && (
+              <div className="opacity-80">
+                {constellationCreatedAtRef.current[activeConst.id]}
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -1074,13 +1200,13 @@ export default function StarSkyDate({
           onPointerDown={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between">
-            <div className="text-white/85 text-sm">크기 조절 (0.2x ~ 1.0x)</div>
+            <div className="text-white/85 text-sm">크기 조절 (0.5x ~ 2.0x)</div>
             <div className="text-white/70 text-xs">x{scaleUI.toFixed(2)}</div>
           </div>
           <input
             type="range"
-            min={0.2}
-            max={1.0}
+            min={0.5}
+            max={2.0}
             step={0.02}
             value={scaleUI}
             onChange={(e) => {
@@ -1090,34 +1216,33 @@ export default function StarSkyDate({
             }}
           />
           <div className="flex items-center justify-between text-white/70 text-xs">
-            <span>0.2x</span>
             <span>0.5x</span>
             <span>1.0x</span>
+            <span>2.0x</span>
           </div>
           <button
             className="px-3 py-1.5 rounded bg-white/75 hover:bg-white text-black text-sm"
             onClick={() => {
               if (!previewMap) {
-                if (originalPositionRef.current) {
-                  setPreviewMap(null);
-                  onTransformEnd?.(originalPositionRef.current);
-                  singleScaleOriginRef.current = originalPositionRef.current;
-                }
                 setPendingApply(false);
                 return;
               }
               const ok = window.confirm("이 위치로 적용하시겠습니까?");
               if (!ok) {
                 if (originalPositionRef.current) {
+                  appliedMapRef.current["single"] = deepClone(
+                    originalPositionRef.current
+                  );
                   setPreviewMap(null);
                   onTransformEnd?.(originalPositionRef.current);
-                  singleScaleOriginRef.current = originalPositionRef.current;
+                  setAppliedVersion((v) => v + 1);
                 }
                 setPendingApply(false);
                 return;
               }
               applyScalePreviewSingle(scaleUI, { commit: true });
-              onApply?.(previewMap);
+              const applied = appliedMapRef.current["single"] || previewMap;
+              onApply?.(applied);
               setPreviewMap(null);
               setPendingApply(false);
               setIsSelected(true);
@@ -1146,8 +1271,8 @@ export default function StarSkyDate({
           </div>
           <input
             type="range"
-            min={0.2}
-            max={1.0}
+            min={0.5}
+            max={2.0}
             step={0.05}
             value={
               scaleUIMap[activeConstellationId] ??
@@ -1155,7 +1280,9 @@ export default function StarSkyDate({
               1
             }
             onChange={(e) => {
-              const v = parseFloat(e.target.value);
+              const vRaw = parseFloat(e.target.value);
+              const v = Math.max(0.5, Math.min(2.0, vRaw));
+
               setScaleUIMap((prev) => ({
                 ...prev,
                 [activeConstellationId]: v,
@@ -1200,8 +1327,8 @@ export default function StarSkyDate({
             }}
           />
           <div className="flex items-center justify-between text-white/70 text-xs">
-            <span>0.2x</span>
-            <span>1.0x</span>
+            <span>0.5x</span>
+            <span>2.0x</span>
           </div>
           <button
             className="px-3 py-1.5 rounded bg-white/75 hover:bg-white text-black text-sm"

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useMemo, useState, useEffect, useRef } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { CiMenuBurger } from "react-icons/ci";
 import Sidebar from "../components/Sidebar";
 import EmotionModal from "../components/EmotionModal";
@@ -18,27 +18,11 @@ import imgPurple from "../assets/emotions/purple.png";
 import imgYellow from "../assets/emotions/yellow.png";
 
 const MONTH_NAMES = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
+  "January","February","March","April","May","June",
+  "July","August","September","October","November","December",
 ];
 const WEEKDAY_NAMES = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
+  "Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday",
 ];
 
 const COLOR_IMAGE = {
@@ -92,9 +76,16 @@ function ymd(date) {
   const d = String(date.getDate()).padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
+function parseISODate(iso) {
+  if (!iso) return null;
+  const d = new Date(`${iso}T00:00:00`);
+  return isNaN(d.getTime()) ? null : d;
+}
 
 function Calendar() {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const [viewDate, setViewDate] = useState(
     () => new Date(new Date().getFullYear(), new Date().getMonth(), 1)
   );
@@ -110,6 +101,8 @@ function Calendar() {
   const [selectedDate, setSelectedDate] = useState(null);
   const [pickedEmotion, setPickedEmotion] = useState("");
   const [selectedTags, setSelectedTags] = useState([]);
+
+  const didOpenFromQueryRef = useRef(false);
 
   const userName =
     localStorage.getItem("nickname") ||
@@ -281,6 +274,24 @@ function Calendar() {
       }
     }
   };
+
+
+  useEffect(() => {
+    const search = new URLSearchParams(location.search);
+    const qDate = search.get("date"); // yyyy-mm-dd
+    if (!qDate || didOpenFromQueryRef.current) return;
+
+    const d = parseISODate(qDate);
+    if (!d) return;
+
+ 
+    setViewDate(new Date(d.getFullYear(), d.getMonth(), 1));
+
+    setTimeout(() => {
+      didOpenFromQueryRef.current = true;
+      openModalFor(d);
+    }, 0);
+  }, [location.search]);
 
   const year = viewDate.getFullYear();
   const month = viewDate.getMonth();

--- a/src/pages/StarArchive.jsx
+++ b/src/pages/StarArchive.jsx
@@ -23,11 +23,12 @@ const StarArchive = () => {
   const openDetail = !!selected;
   const selectedId = selected?.constellationId;
 
+  const [selectedIndex, setSelectedIndex] = useState(null);
+
   const [repTarget, setRepTarget] = useState(null);
   const openRepModal = !!repTarget;
 
   const { data: detail } = useConstellationDetail(selectedId, openDetail);
-
 
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 4;
@@ -74,8 +75,7 @@ const StarArchive = () => {
           me = myEmail ? data.find((u) => u?.email === myEmail) : data[0];
         }
 
-        const nk =
-          me?.nickname ?? me?.user?.nickname ?? me?.profile?.nickname ?? "";
+        const nk = me?.nickname ?? me?.user?.nickname ?? me?.profile?.nickname ?? "";
 
         if (!cancelled) {
           setNickname(nk);
@@ -111,9 +111,7 @@ const StarArchive = () => {
       );
 
       setSelected((prev) =>
-        prev && prev.constellationId === id
-          ? { ...prev, isRepresentative: true }
-          : prev
+        prev && prev.constellationId === id ? { ...prev, isRepresentative: true } : prev
       );
 
       setRepTarget(null);
@@ -128,83 +126,59 @@ const StarArchive = () => {
 
   const totalPages = Math.ceil((archivesState?.length || 0) / pageSize) || 1;
   const startIndex = (currentPage - 1) * pageSize;
-  const currentItems =
-    archivesState?.slice(startIndex, startIndex + pageSize) || [];
+  const currentItems = archivesState?.slice(startIndex, startIndex + pageSize) || [];
 
   return (
-     <div className=" flex flex-col overflow-hidden text-white ">
+    <div className=" flex flex-col overflow-hidden text-white ">
       <Sidebar isOpen={isOpen} setIsOpen={setIsOpen} />
       {isOpen && (
-        <div
-          className="fixed inset-0 z-40"
-          aria-hidden="true"
-          onClick={() => setIsOpen(false)}
-        />
+        <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setIsOpen(false)} />
       )}
 
       <div className="flex flex-row justify-between">
-        <button
-          className="ml-[1.81rem] mt-[2.13rem]"
-          onClick={handleBurgerClick}
-          aria-label="open sidebar"
-        >
+        <button className="ml-[1.81rem] mt-[2.13rem]" onClick={handleBurgerClick} aria-label="open sidebar">
           <CiMenuBurger size={30} />
         </button>
       </div>
 
       <div className="flex flex-col items-center">
         <span className="font-julius mt-5 text-7xl">STARLET ARCHIVE</span>
-        {nickname && (
-          <span className="mt-4 text-2xl text-center">
-            {nickname}님의 별자리를 확인해보세요
-          </span>
-        )}
+        {nickname && <span className="mt-4 text-2xl text-center">{nickname}님의 별자리를 확인해보세요</span>}
       </div>
 
-      
       <div className="p-12 pl-32 ">
         {loading && <div className="text-white/80">불러오는 중…</div>}
-        {error && (
-          <div className="text-red-300">
-            데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요.
-          </div>
-        )}
+        {error && <div className="text-red-300">데이터를 불러오지 못했어요. 잠시 후 다시 시도해주세요.</div>}
         {!loading && !error && (!archivesState || archivesState.length === 0) && (
           <div className="text-white/70">아카이브가 비어 있어요.</div>
         )}
 
         {!!archivesState && archivesState.length > 0 && (
           <div className="grid gap-16 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-2">
-            {currentItems.map((item) => (
-              <div
+            {currentItems.map((item, i) => (
+              <StarArchiveCard
                 key={item.constellationId}
-                onClick={() => setSelected(item)}
-              >
-                <StarArchiveCard
-                  item={item}
-                  onStarClick={(e) => {
-                    e.stopPropagation();
-                    setRepTarget(item);
-                  }}
-                />
-              </div>
+                item={item}
+                onOpen={() => {
+                  setSelected(item);
+                  setSelectedIndex(startIndex + i); // 전체 목록 기준 인덱스
+                }}
+                onStarClick={(e) => {
+                  e.stopPropagation();
+                  setRepTarget(item);
+                }}
+              />
             ))}
           </div>
         )}
       </div>
 
-
       {!!archivesState && archivesState.length > 0 && (
         <div className="flex justify-center items-center text-2xl select-none mb-8">
-
           <button
             onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
             disabled={currentPage === 1}
-            className={`mx-4 ${
-              currentPage === 1
-                ? "opacity-50"
-                : "hover:text-blue-300"
-            }`}
+            className={`mx-4 ${currentPage === 1 ? "opacity-50" : "hover:text-blue-300"}`}
           >
             {"<"}
           </button>
@@ -214,11 +188,7 @@ const StarArchive = () => {
           <button
             onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
             disabled={currentPage === totalPages}
-            className={`mx-4 ${
-              currentPage === totalPages
-                ? "opacity-50d"
-                : "hover:text-blue-300"
-            }`}
+            className={`mx-4 ${currentPage === totalPages ? "opacity-50d" : "hover:text-blue-300"}`}
           >
             {">"}
           </button>
@@ -230,6 +200,10 @@ const StarArchive = () => {
         onClose={() => setSelected(null)}
         initial={selected}
         detail={detail}
+        items={archivesState || []}
+        index={selectedIndex ?? 0}
+        onChangeIndex={setSelectedIndex}
+        loop={true}
       />
 
       <RepresentativeConfirmModal

--- a/src/pages/StarArchive.jsx
+++ b/src/pages/StarArchive.jsx
@@ -195,16 +195,19 @@ const StarArchive = () => {
         </div>
       )}
 
-      <ConstellationDetailModal
-        open={openDetail}
-        onClose={() => setSelected(null)}
-        initial={selected}
-        detail={detail}
-        items={archivesState || []}
-        index={selectedIndex ?? 0}
-        onChangeIndex={setSelectedIndex}
-        loop={true}
-      />
+    <ConstellationDetailModal
+  open={openDetail}
+  onClose={() => setSelected(null)}
+  initial={selected}
+  detail={selectedId === detail?.constellationId ? detail : null}  
+  items={archivesState || []}
+  index={selectedIndex ?? 0}
+  onChangeIndex={(i) => {
+    setSelectedIndex(i);
+    setSelected(archivesState[i]); 
+  }}
+  loop={true}
+/>
 
       <RepresentativeConfirmModal
         open={openRepModal}

--- a/src/pages/StarSky.jsx
+++ b/src/pages/StarSky.jsx
@@ -113,12 +113,6 @@ const StarSky = () => {
     if (!Array.isArray(rawList)) return [];
 
     return rawList.map((c) => {
-      const baseDate =
-        c.createdAt ||
-        c.createdDate ||
-        c.date ||
-        (c.stars?.[0]?.date ?? new Date().toISOString().slice(0, 10));
-
       const rawStars =
         c.stars || c.starts || c.starList || c.star || c.starEntities || [];
 
@@ -139,12 +133,20 @@ const StarSky = () => {
           ? c.description
           : cached?.desc || "";
 
+      const baseDate =
+        cached?.createdAt ||
+        c.createdAt ||
+        c.createdDate ||
+        c.date ||
+        (rawStars[0]?.date ?? new Date().toISOString().slice(0, 10));
+
       return {
         id: c.constellationId ?? c.id,
         constellationId: c.constellationId ?? c.id,
         name: finalName,
         description: finalDesc,
         createdAt: baseDate,
+        constellationCreatedAt: baseDate,
         x: typeof c.x === "number" ? clamp01(c.x) : 0.5,
         y: typeof c.y === "number" ? clamp01(c.y) : 0.5,
         stars: rawStars.map((s) => ({
@@ -361,6 +363,7 @@ const StarSky = () => {
         [key]: {
           name: trimmedName || "미지정 별자리",
           desc: trimmedDesc || "",
+          createdAt: createdAtStr,
         },
       };
       saveNameCache(nameCacheRef.current);


### PR DESCRIPTION
## #️⃣연관된 이슈

- X

## 📝작업 내용
- 별자리 아카이브에서 ```별자리 카드``` 클릭 시 상세페이지 랜더링 ( ```스크린샷 1``` 참고 )
- 상세페이지 안에 표시되는 정보
```
 1.  별자리 생성날짜
 2. 별자리 이름, 설졍
 3. 해당 별자리에 포함된 별과 그 별에 대한 감정
 4. 별자리 생성 날짜
 ```
- 생성 날짜 클릭 시 해당 날짜 일기장으로 이동
- 모달창 옆 방향키 클릭 시 다른 별자리 상세페이지로 이동, 순환 loop 사용
```
  const goIdx = (next) => {
    if (!canNav || !onChangeIndex) return;
    const n = loop ? (next + total) % total : Math.min(Math.max(next, 0), total - 1);
    onChangeIndex(n);
  };
```
### 스크린샷 (선택)
<img width="2557" height="1378" alt="image" src="https://github.com/user-attachments/assets/b6185865-c265-45d3-b23b-59aea4510e78" />

## 💬리뷰 요구사항(선택)
- 피그마에 표시되어있는 수정 클릭 시 별자리 이름과 내용을 수정하는 기능은 새 브랜치로 작업할 예정입니다. 작업 내용 바탕으로 기능 확인 부탁드립니다.