### PR TITLE
fix : 별이 생성될 때 3개의 UI 영역에 스폰되지 않게 수정

### DIFF
--- a/src/components/StarSkyDate.jsx
+++ b/src/components/StarSkyDate.jsx
@@ -443,6 +443,37 @@ export default function StarSkyDate({
     onTransformEnd,
   ]);
 
+  useEffect(() => {
+    if (locked) return;
+    if (!containerRef.current) return;
+    if (!filteredStars.length) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+
+    const baseMap =
+      appliedMapRef.current["single"] ||
+      Object.fromEntries(filteredStars.map((s) => [s.id, { x: s.x, y: s.y }]));
+
+    let changed = false;
+    const nextMap = { ...baseMap };
+
+    filteredStars.forEach((s) => {
+      const cur = baseMap[s.id] || { x: s.x, y: s.y };
+      const adjusted = avoidUiZones(cur.x, cur.y, rect);
+
+      if (adjusted.x !== cur.x || adjusted.y !== cur.y) {
+        changed = true;
+        nextMap[s.id] = { x: adjusted.x, y: adjusted.y };
+        onMove?.(s.id, adjusted.x, adjusted.y);
+      }
+    });
+
+    if (changed) {
+      appliedMapRef.current["single"] = nextMap;
+      setAppliedVersion((v) => v + 1);
+    }
+  }, [filteredStars, locked, onMove]);
+
   const toRel = (clientX, clientY) => {
     const r = containerRef.current.getBoundingClientRect();
     return {


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

> 별이 생성될 때 Generate 버튼, 달 이동 버튼, 사이드바에는 나타나지 않도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
